### PR TITLE
feat: 공통으로 정의하는 생성, 업데이트 속성 클래스 (#13)

### DIFF
--- a/src/main/java/com/codenear/butterfly/common/domain/BaseEntity.java
+++ b/src/main/java/com/codenear/butterfly/common/domain/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.codenear.butterfly.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #12 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- Entity 에 공통적으로 정의하는 속성 추가해 편리하게 상속 받아 사용 가능

- 참고 자료
https://dmaolon00.tistory.com/entry/Spring-%EA%B3%B5%ED%86%B5-%ED%95%84%EB%93%9C-%ED%95%98%EB%82%98%EB%A1%9C-%EB%AC%B6%EA%B8%B0-BaseEntity-JpaAuditing
