### PR TITLE
19 회원 가입 및 로그인 로직

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ out/
 
 ### Security ###
 **/application-common.properties
+**/application-secret.properties
+**/application-local.properties

--- a/src/main/java/com/codenear/butterfly/ButterflyApplication.java
+++ b/src/main/java/com/codenear/butterfly/ButterflyApplication.java
@@ -2,9 +2,10 @@ package com.codenear.butterfly;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication
+@EnableJpaAuditing
 public class ButterflyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/codenear/butterfly/auth/application/AuthService.java
+++ b/src/main/java/com/codenear/butterfly/auth/application/AuthService.java
@@ -1,0 +1,38 @@
+package com.codenear.butterfly.auth.application;
+
+import com.codenear.butterfly.member.domain.Grade;
+import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.member.domain.repository.MemberRepository;
+import com.codenear.butterfly.auth.domain.dto.AuthRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+
+    public void registerOrLogin(AuthRequestDTO requestDTO) {
+        Optional<Member> member = memberRepository.findByEmailAndPlatform(requestDTO.getEmail(), requestDTO.getPlatform());
+
+        if (member.isEmpty()) { // 회원 정보 DB 저장
+            Member registerMember = register(requestDTO);
+            memberRepository.save(registerMember);
+        }
+    }
+
+    private Member register(AuthRequestDTO requestDTO) {
+        return Member.builder()
+                .email(requestDTO.getEmail())
+                .nickname(requestDTO.getNickname())
+                .point(0)
+                .grade(Grade.LEVEL_1)
+                .platform(requestDTO.getPlatform())
+                .build();
+    }
+}

--- a/src/main/java/com/codenear/butterfly/auth/domain/dto/AuthRequestDTO.java
+++ b/src/main/java/com/codenear/butterfly/auth/domain/dto/AuthRequestDTO.java
@@ -1,0 +1,13 @@
+package com.codenear.butterfly.auth.domain.dto;
+
+import com.codenear.butterfly.member.domain.Platform;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthRequestDTO {
+    private String email;
+    private String nickname;
+    private Platform platform;
+}

--- a/src/main/java/com/codenear/butterfly/auth/presentation/AuthController.java
+++ b/src/main/java/com/codenear/butterfly/auth/presentation/AuthController.java
@@ -1,0 +1,22 @@
+package com.codenear.butterfly.auth.presentation;
+
+import com.codenear.butterfly.auth.domain.dto.AuthRequestDTO;
+import com.codenear.butterfly.auth.application.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody AuthRequestDTO authRequestDTO) {
+        authService.registerOrLogin(authRequestDTO);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Member extends BaseEntity {
 
@@ -14,7 +17,7 @@ public class Member extends BaseEntity {
 
     private String username;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(unique = true)

--- a/src/main/java/com/codenear/butterfly/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/repository/MemberRepository.java
@@ -1,7 +1,11 @@
 package com.codenear.butterfly.member.domain.repository;
 
 import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.member.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmailAndPlatform(String email, Platform platform);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=butterfly
 
+spring.profiles.active=local
 spring.profiles.include=common


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #18 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 초반에 설정했던, 업데이트 및 추가 날짜 선언해주는 JPA 활성화를 위해 시작 부분에 Auto Jpa 애노테이션 설정
- 좀 더 간편하게 사용하기 위해 @Builder 애노테이션 적용
- FE 측 전달 받은 데이터 기반 회원가입/로그인 

## 🔧 앞으로의 과제

- FE 협업을 위한 Swagger 문서화
- JWT, Security 적용