### PR TITLE
108 refactor member entity point 분리

### DIFF
--- a/src/main/java/com/codenear/butterfly/auth/application/OauthService.java
+++ b/src/main/java/com/codenear/butterfly/auth/application/OauthService.java
@@ -33,13 +33,12 @@ public class OauthService {
     }
 
     private Member createMember(OauthDTO dto) {
-        return Member.builder()
-                .email(dto.getEmail())
-                .password(dto.getOauthId())
-                .nickname(nicknameService.generateNickname())
-                .point(0)
-                .grade(Grade.EGG)
-                .platform(dto.getPlatform())
-                .build();
+        return Member.createMemberWithPoint(
+                dto.getEmail(),
+                dto.getOauthId(),
+                nicknameService.generateNickname(),
+                Grade.EGG,
+                dto.getPlatform()
+        );
     }
 }

--- a/src/main/java/com/codenear/butterfly/auth/application/OauthService.java
+++ b/src/main/java/com/codenear/butterfly/auth/application/OauthService.java
@@ -5,6 +5,7 @@ import com.codenear.butterfly.member.application.NicknameService;
 import com.codenear.butterfly.member.domain.Grade;
 import com.codenear.butterfly.member.domain.Member;
 import com.codenear.butterfly.member.domain.repository.member.MemberRepository;
+import com.codenear.butterfly.point.domain.Point;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,12 +34,20 @@ public class OauthService {
     }
 
     private Member createMember(OauthDTO dto) {
-        return Member.createMemberWithPoint(
-                dto.getEmail(),
-                dto.getOauthId(),
-                nicknameService.generateNickname(),
-                Grade.EGG,
-                dto.getPlatform()
-        );
+        Member member = Member.builder()
+                .email(dto.getEmail())
+                .password(dto.getOauthId())
+                .nickname(nicknameService.generateNickname())
+                .grade(Grade.EGG)
+                .platform(dto.getPlatform())
+                .build();
+
+        Point point = Point.builder()
+                .point(0)
+                .build();
+
+        member.setPoint(point);
+
+        return member;
     }
 }

--- a/src/main/java/com/codenear/butterfly/auth/application/email/EmailRegisterService.java
+++ b/src/main/java/com/codenear/butterfly/auth/application/email/EmailRegisterService.java
@@ -51,13 +51,12 @@ public class EmailRegisterService {
     }
 
     private Member register(AuthRegisterDTO requestDTO) {
-        return Member.builder()
-                .email(requestDTO.getEmail())
-                .nickname(requestDTO.getNickname())
-                .password(passwordEncoder.encode(requestDTO.getPassword()))
-                .point(0)
-                .grade(Grade.EGG)
-                .platform(Platform.CODENEAR)
-                .build();
+        return Member.createMemberWithPoint(
+                requestDTO.getEmail(),
+                passwordEncoder.encode(requestDTO.getPassword()),
+                requestDTO.getNickname(),
+                Grade.EGG,
+                Platform.CODENEAR
+        );
     }
 }

--- a/src/main/java/com/codenear/butterfly/auth/application/email/EmailRegisterService.java
+++ b/src/main/java/com/codenear/butterfly/auth/application/email/EmailRegisterService.java
@@ -8,6 +8,7 @@ import com.codenear.butterfly.member.domain.Member;
 import com.codenear.butterfly.member.domain.Platform;
 import com.codenear.butterfly.member.domain.repository.member.MemberRepository;
 import com.codenear.butterfly.member.util.ForbiddenWordFilter;
+import com.codenear.butterfly.point.domain.Point;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -51,12 +52,20 @@ public class EmailRegisterService {
     }
 
     private Member register(AuthRegisterDTO requestDTO) {
-        return Member.createMemberWithPoint(
-                requestDTO.getEmail(),
-                passwordEncoder.encode(requestDTO.getPassword()),
-                requestDTO.getNickname(),
-                Grade.EGG,
-                Platform.CODENEAR
-        );
+        Member member = Member.builder()
+                .email(requestDTO.getEmail())
+                .password(passwordEncoder.encode(requestDTO.getPassword()))
+                .nickname(requestDTO.getNickname())
+                .grade(Grade.EGG)
+                .platform(Platform.CODENEAR)
+                .build();
+
+        Point point = Point.builder()
+                .point(0)
+                .build();
+
+        member.setPoint(point);
+
+        return member;
     }
 }

--- a/src/main/java/com/codenear/butterfly/member/application/MemberService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/MemberService.java
@@ -21,7 +21,7 @@ public class MemberService {
                 member.getNickname(),
                 member.getProfileImage(),
                 member.getGrade(),
-                member.getPoint()
+                member.getPoint().getPoint()
         );
     }
 }

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -43,25 +43,7 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Point point;
 
-    public static Member createMemberWithPoint(String email, String password, String nickname, Grade grade, Platform platform) {
-        Member member = Member.builder()
-                .email(email)
-                .password(password)
-                .nickname(nickname)
-                .grade(grade)
-                .platform(platform)
-                .build();
-
-        Point point = Point.builder()
-                .point(0)
-                .build();
-
-        member.setPoint(point);
-
-        return member;
-    }
-
-    private void setPoint(Point point) {
+    public void setPoint(Point point) {
         this.point = point;
         point.setMember(this);
     }

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -1,9 +1,9 @@
 package com.codenear.butterfly.member.domain;
 
 import com.codenear.butterfly.global.domain.BaseEntity;
+import com.codenear.butterfly.point.domain.Point;
 import jakarta.persistence.*;
 import lombok.*;
-
 
 @Entity
 @Builder
@@ -29,17 +29,40 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
-    //todo : 기본 이미지 설정
     private String profileImage;
 
     //todo : 주소 테이블로 옮길지, 1:N 연결 고려
     private String address;
-
-    private Integer point;
 
     @Enumerated(EnumType.STRING)
     private Grade grade;
 
     @Enumerated(EnumType.STRING)
     private Platform platform;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Point point;
+
+    public static Member createMemberWithPoint(String email, String password, String nickname, Grade grade, Platform platform) {
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .grade(grade)
+                .platform(platform)
+                .build();
+
+        Point point = Point.builder()
+                .point(0)
+                .build();
+
+        member.setPoint(point);
+
+        return member;
+    }
+
+    private void setPoint(Point point) {
+        this.point = point;
+        point.setMember(this);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/member/presentation/MemberController.java
+++ b/src/main/java/com/codenear/butterfly/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.member.application.MemberService;
 import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.member.presentation.swagger.MemberControllerSwagger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/codenear/butterfly/member/presentation/NicknameController.java
+++ b/src/main/java/com/codenear/butterfly/member/presentation/NicknameController.java
@@ -3,6 +3,7 @@ package com.codenear.butterfly.member.presentation;
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.member.application.NicknameService;
+import com.codenear.butterfly.member.presentation.swagger.NicknameControllerSwagger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/codenear/butterfly/member/presentation/swagger/MemberControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/member/presentation/swagger/MemberControllerSwagger.java
@@ -1,4 +1,4 @@
-package com.codenear.butterfly.member.presentation;
+package com.codenear.butterfly.member.presentation.swagger;
 
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.member.domain.Member;

--- a/src/main/java/com/codenear/butterfly/member/presentation/swagger/NicknameControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/member/presentation/swagger/NicknameControllerSwagger.java
@@ -1,4 +1,4 @@
-package com.codenear.butterfly.member.presentation;
+package com.codenear.butterfly.member.presentation.swagger;
 
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/codenear/butterfly/point/domain/Point.java
+++ b/src/main/java/com/codenear/butterfly/point/domain/Point.java
@@ -1,0 +1,24 @@
+package com.codenear.butterfly.point.domain;
+
+import com.codenear.butterfly.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Point {
+
+    @Id
+    private Long id;
+
+    private Integer point;
+
+    @Setter
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "member_id")
+    private Member member;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #108

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- Member, Point 분리 작업
- 분리로 인한 회원가입 로직 변경
- 일반, 소셜 회원가입 로직 공통적으로 처리하기 위해 domain 메서드 정의
