### PR TITLE
115 고객 문의 관련 도메인 정의

### DIFF
--- a/src/main/java/com/codenear/butterfly/admin/support/presentation/AdminInquiryController.java
+++ b/src/main/java/com/codenear/butterfly/admin/support/presentation/AdminInquiryController.java
@@ -1,0 +1,16 @@
+package com.codenear.butterfly.admin.support.presentation;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin/support/inquiry")
+public class AdminInquiryController {
+
+    @GetMapping
+    public String inquiryList(Model model) {
+        return "admin/support/inquiryList";
+    }
+}

--- a/src/main/java/com/codenear/butterfly/support/domain/Inquiry.java
+++ b/src/main/java/com/codenear/butterfly/support/domain/Inquiry.java
@@ -1,0 +1,31 @@
+package com.codenear.butterfly.support.domain;
+
+import com.codenear.butterfly.global.domain.BaseEntity;
+import com.codenear.butterfly.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Inquiry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String inquiryContent;
+
+    @Column(length = 1000)
+    private String responseContent;
+
+    @Enumerated(EnumType.STRING)
+    private InquiryStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/codenear/butterfly/support/domain/InquiryRepository.java
+++ b/src/main/java/com/codenear/butterfly/support/domain/InquiryRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
-    Optional<List<Inquiry>> findByMember(Member member);
+    List<Inquiry> findByMember(Member member);
 }

--- a/src/main/java/com/codenear/butterfly/support/domain/InquiryRepository.java
+++ b/src/main/java/com/codenear/butterfly/support/domain/InquiryRepository.java
@@ -1,0 +1,11 @@
+package com.codenear.butterfly.support.domain;
+
+import com.codenear.butterfly.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+    Optional<List<Inquiry>> findByMember(Member member);
+}

--- a/src/main/java/com/codenear/butterfly/support/domain/InquiryStatus.java
+++ b/src/main/java/com/codenear/butterfly/support/domain/InquiryStatus.java
@@ -1,0 +1,6 @@
+package com.codenear.butterfly.support.domain;
+
+public enum InquiryStatus {
+    PENDING,
+    ANSWERED
+}

--- a/src/main/java/com/codenear/butterfly/support/domain/dto/InquiryListDTO.java
+++ b/src/main/java/com/codenear/butterfly/support/domain/dto/InquiryListDTO.java
@@ -1,0 +1,6 @@
+package com.codenear.butterfly.support.domain.dto;
+
+import com.codenear.butterfly.support.domain.InquiryStatus;
+
+public record InquiryListDTO(Long id, String inquiryContent, String responseContent, InquiryStatus status) {
+}

--- a/src/main/java/com/codenear/butterfly/support/domain/dto/InquiryRegisterDTO.java
+++ b/src/main/java/com/codenear/butterfly/support/domain/dto/InquiryRegisterDTO.java
@@ -1,0 +1,11 @@
+package com.codenear.butterfly.support.domain.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class InquiryRegisterDTO {
+
+    @Size(min = 5, max = 1000, message = "문의 내용은 최소 5자 이상, 최대 1,000자 이하입니다.")
+    private String inquiryContent;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #112 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 고객 문의 관련 Entity, Repository, DTO 정의

## 🔧 앞으로의 과제

- 고객 문의 조회, 발송 API 생성
- 관리자 페이지 고객 문의 확인 기능
