### PR TITLE
feat: 유저 정보 이메일, 쿠폰 추가 (#197)

### DIFF
--- a/src/main/java/com/codenear/butterfly/member/application/MemberService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/MemberService.java
@@ -21,8 +21,10 @@ public class MemberService {
         Integer pointValue = pointService.loadPointByMemberId(memberDTO.getId()).getPoint();
 
         return new MemberInfoDTO(
+                memberDTO.getEmail(),
                 memberDTO.getNickname(),
                 memberDTO.getProfileImage(),
+                0, // TODO : 추후 쿠폰 시스템 도입 후 수정
                 memberDTO.getGrade().getGrade(),
                 pointValue
         );

--- a/src/main/java/com/codenear/butterfly/member/domain/dto/MemberInfoDTO.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/dto/MemberInfoDTO.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "유저 정보 JSON", description = "유저 정보 요청 시 반환되는 응답 JSON 데이터 입니다.")
 public record MemberInfoDTO(
+        @Schema(description = "회원 이메일") String email,
         @Schema(description = "회원 닉네임") String nickname,
         @Schema(description = "프로필 이미지 URL", example = "http://example.com/profile.jpg") String profileImage,
+        @Schema(description = "쿠폰 갯수") Integer coupon,
         @Schema(description = "회원 등급") Integer grade,
         @Schema(description = "회원 포인트") Integer point) {
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #197 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 유저 정보에 [이메일], [쿠폰] 데이터 추가

## 🌄 이미지 첨부 

![image](https://github.com/user-attachments/assets/fbdbf495-f743-4522-bd71-10d0dc07ad87)
