### PR TITLE
199 feat 마케팅 수신 동의 변동 및 저장 추가

### DIFF
--- a/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
+++ b/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
@@ -1,0 +1,51 @@
+package com.codenear.butterfly.consent.application;
+
+import com.codenear.butterfly.consent.domain.Consent;
+import com.codenear.butterfly.consent.domain.ConsentRepository;
+import com.codenear.butterfly.consent.domain.ConsentType;
+import com.codenear.butterfly.consent.dto.ConsentInfoResponseDTO;
+import com.codenear.butterfly.consent.dto.ConsentSingleResponseDTO;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ConsentService {
+    private final ConsentRepository consentRepository;
+
+    public ConsentInfoResponseDTO getConsentsInfo(MemberDTO memberDTO) {
+        List<Consent> consents = loadConsentsByMemberId(memberDTO);
+        List<ConsentSingleResponseDTO> consentSingleDTOS = getConsentSingleResponseDTOS(consents);
+        return new ConsentInfoResponseDTO(consentSingleDTOS);
+    }
+
+    private List<ConsentSingleResponseDTO> getConsentSingleResponseDTOS(List<Consent> consents) {
+        List<ConsentSingleResponseDTO> responseDTOList = new ArrayList<>();
+
+        for (ConsentType type : ConsentType.values()) {
+            boolean agreed = isAgreed(consents, type);
+            responseDTOList.add(createConsentSingleResponseDTO(type, agreed));
+        }
+        return responseDTOList;
+    }
+
+    private boolean isAgreed(List<Consent> consents, ConsentType type) {
+        return consents.stream()
+                .filter(consent -> consent.getConsentType().equals(type))
+                .map(Consent::isAgreed)
+                .findFirst()
+                .orElse(false);
+    }
+
+    private  ConsentSingleResponseDTO createConsentSingleResponseDTO(ConsentType value, boolean agreed) {
+        return new ConsentSingleResponseDTO(value, agreed);
+    }
+
+    private List<Consent> loadConsentsByMemberId(MemberDTO memberDTO) {
+        return consentRepository.findByMemberId(memberDTO.getId());
+    }
+}

--- a/src/main/java/com/codenear/butterfly/consent/domain/Consent.java
+++ b/src/main/java/com/codenear/butterfly/consent/domain/Consent.java
@@ -1,0 +1,26 @@
+package com.codenear.butterfly.consent.domain;
+
+import com.codenear.butterfly.global.domain.BaseEntity;
+import com.codenear.butterfly.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Consent extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ConsentType consentType;
+
+    private boolean isAgreed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/codenear/butterfly/consent/domain/ConsentRepository.java
+++ b/src/main/java/com/codenear/butterfly/consent/domain/ConsentRepository.java
@@ -1,0 +1,6 @@
+package com.codenear.butterfly.consent.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConsentRepository extends JpaRepository<Consent, Long> {
+}

--- a/src/main/java/com/codenear/butterfly/consent/domain/ConsentRepository.java
+++ b/src/main/java/com/codenear/butterfly/consent/domain/ConsentRepository.java
@@ -2,5 +2,8 @@ package com.codenear.butterfly.consent.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ConsentRepository extends JpaRepository<Consent, Long> {
+    List<Consent> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/codenear/butterfly/consent/domain/ConsentType.java
+++ b/src/main/java/com/codenear/butterfly/consent/domain/ConsentType.java
@@ -1,0 +1,6 @@
+package com.codenear.butterfly.consent.domain;
+
+public enum ConsentType {
+    MARKETING,
+    DELIVERY
+}

--- a/src/main/java/com/codenear/butterfly/consent/dto/ConsentInfoResponseDTO.java
+++ b/src/main/java/com/codenear/butterfly/consent/dto/ConsentInfoResponseDTO.java
@@ -1,0 +1,11 @@
+package com.codenear.butterfly.consent.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(title = "수신 동의 리스트 JSON", description = "수신 동의 리스트 요청 시 반환되는 응답 JSON 데이터 입니다.")
+public record ConsentInfoResponseDTO(
+        @Schema(description = "수신 동의 리스트") List<ConsentSingleResponseDTO> consents
+) {
+}

--- a/src/main/java/com/codenear/butterfly/consent/dto/ConsentSingleResponseDTO.java
+++ b/src/main/java/com/codenear/butterfly/consent/dto/ConsentSingleResponseDTO.java
@@ -1,0 +1,11 @@
+package com.codenear.butterfly.consent.dto;
+
+import com.codenear.butterfly.consent.domain.ConsentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "수신 동의 단일 JSON", description = "수신 동의 리스트 요청 시 반환되는 응답 JSON 중 단일 데이터 입니다.")
+public record ConsentSingleResponseDTO(
+        @Schema(description = "동의 종류") ConsentType consentType,
+        @Schema(description = "동의 여부") boolean isAgreed
+) {
+}

--- a/src/main/java/com/codenear/butterfly/consent/presentation/ConsentController.java
+++ b/src/main/java/com/codenear/butterfly/consent/presentation/ConsentController.java
@@ -1,0 +1,24 @@
+package com.codenear.butterfly.consent.presentation;
+
+import com.codenear.butterfly.consent.application.ConsentService;
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.global.util.ResponseUtil;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/consent")
+@RequiredArgsConstructor
+public class ConsentController implements ConsentControllerSwagger {
+    private final ConsentService consentService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO> getConsents(@AuthenticationPrincipal MemberDTO memberDTO) {
+        return ResponseUtil.createSuccessResponse(consentService.getConsentsInfo(memberDTO));
+    }
+}

--- a/src/main/java/com/codenear/butterfly/consent/presentation/ConsentControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/consent/presentation/ConsentControllerSwagger.java
@@ -3,7 +3,6 @@ package com.codenear.butterfly.consent.presentation;
 import com.codenear.butterfly.consent.dto.ConsentInfoResponseDTO;
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
-import com.codenear.butterfly.support.domain.dto.InquiryListDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/codenear/butterfly/consent/presentation/ConsentControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/consent/presentation/ConsentControllerSwagger.java
@@ -1,0 +1,26 @@
+package com.codenear.butterfly.consent.presentation;
+
+import com.codenear.butterfly.consent.dto.ConsentInfoResponseDTO;
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.support.domain.dto.InquiryListDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Consent", description = "**수신 동의 API**")
+public interface ConsentControllerSwagger {
+
+    @Operation(summary = "수신 동의 리스트", description = "수신 동의 리스트 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "body", description = "응답 메시지 예시",
+                    content = @Content(schema = @Schema(implementation = ConsentInfoResponseDTO.class))),
+            @ApiResponse(responseCode = "200", description = "Success")
+    })
+    ResponseEntity<ResponseDTO> getConsents(@AuthenticationPrincipal MemberDTO memberDTO);
+}

--- a/src/main/java/com/codenear/butterfly/global/config/SwaggerConfig.java
+++ b/src/main/java/com/codenear/butterfly/global/config/SwaggerConfig.java
@@ -45,7 +45,8 @@ public class SwaggerConfig {
             createGroupedOpenApi("고객 문의 API", "/support/**"),
             createGroupedOpenApi("검색 API", "/search/**"),
             createGroupedOpenApi("주소 API", "/address/**"),
-            createGroupedOpenApi("카카오페이 단건결제 API", "/payment/**")
+            createGroupedOpenApi("카카오페이 단건결제 API", "/payment/**"),
+            createGroupedOpenApi("수신 동의 API", "/consent/**")
         );
     }
 

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -20,6 +20,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -20,7 +20,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.codenear.butterfly.member.domain;
 
 import com.codenear.butterfly.address.domain.Address;
+import com.codenear.butterfly.consent.domain.Consent;
 import com.codenear.butterfly.global.domain.BaseEntity;
 import com.codenear.butterfly.point.domain.Point;
 import com.codenear.butterfly.product.domain.Favorite;
@@ -46,8 +47,11 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Platform platform;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
     private Point point;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Consent> consents = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorite> favorites = new ArrayList<>();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #199 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 마케팅 수신 동의 목록 반환 API 추가

## 🌄 이미지 첨부

![image](https://github.com/user-attachments/assets/c1e75fc5-9b3b-4594-b666-08d27940cdc3)

![image](https://github.com/user-attachments/assets/361f5bbe-1261-419c-9430-b12e8d350803)

## 🔧 앞으로의 과제 

- 수신 동의 변경 API 추가
