### PR TITLE
199 feat 마케팅 수신 동의 변동 및 저장 추가

### DIFF
--- a/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
+++ b/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
@@ -5,17 +5,23 @@ import com.codenear.butterfly.consent.domain.ConsentRepository;
 import com.codenear.butterfly.consent.domain.ConsentType;
 import com.codenear.butterfly.consent.dto.ConsentInfoResponseDTO;
 import com.codenear.butterfly.consent.dto.ConsentSingleResponseDTO;
+import com.codenear.butterfly.consent.dto.ConsentUpdateRequestDTO;
+import com.codenear.butterfly.member.application.MemberService;
+import com.codenear.butterfly.member.domain.Member;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ConsentService {
     private final ConsentRepository consentRepository;
+    private final MemberService memberService;
 
     public ConsentInfoResponseDTO getConsentsInfo(MemberDTO memberDTO) {
         List<Consent> consents = loadConsentsByMemberId(memberDTO);
@@ -47,5 +53,26 @@ public class ConsentService {
 
     private List<Consent> loadConsentsByMemberId(MemberDTO memberDTO) {
         return consentRepository.findByMemberId(memberDTO.getId());
+    }
+
+    public void updateConsent(ConsentUpdateRequestDTO updateRequestDTO, MemberDTO memberDTO) {
+        List<Consent> consents = loadConsentsByMemberId(memberDTO);
+        ConsentType type = updateRequestDTO.getConsentType();
+
+        Consent consent = consents.stream()
+                .filter(findConsent -> findConsent.getConsentType().equals(type))
+                .findFirst()
+                .orElseGet(() -> createConsent(type, false, memberService.loadMemberByMemberId(memberDTO.getId())));
+
+        consent.toggleAgreement();
+        consentRepository.save(consent);
+    }
+
+    private Consent createConsent(ConsentType type, boolean agreed, Member member) {
+        return Consent.builder()
+                .consentType(type)
+                .isAgreed(agreed)
+                .member(member)
+                .build();
     }
 }

--- a/src/main/java/com/codenear/butterfly/consent/domain/Consent.java
+++ b/src/main/java/com/codenear/butterfly/consent/domain/Consent.java
@@ -23,4 +23,8 @@ public class Consent extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void toggleAgreement() {
+        this.isAgreed = !this.isAgreed;
+    }
 }

--- a/src/main/java/com/codenear/butterfly/consent/dto/ConsentUpdateRequestDTO.java
+++ b/src/main/java/com/codenear/butterfly/consent/dto/ConsentUpdateRequestDTO.java
@@ -1,0 +1,13 @@
+package com.codenear.butterfly.consent.dto;
+
+import com.codenear.butterfly.consent.domain.ConsentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(title = "수신 동의 변경 JSON", description = "수신 동의 변경 시 정의되는 JSON 데이터 입니다.")
+@Getter
+public class ConsentUpdateRequestDTO {
+
+    @Schema(description = "동의 종류")
+    private ConsentType consentType;
+}

--- a/src/main/java/com/codenear/butterfly/consent/presentation/ConsentController.java
+++ b/src/main/java/com/codenear/butterfly/consent/presentation/ConsentController.java
@@ -1,15 +1,15 @@
 package com.codenear.butterfly.consent.presentation;
 
 import com.codenear.butterfly.consent.application.ConsentService;
+import com.codenear.butterfly.consent.dto.ConsentUpdateRequestDTO;
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/consent")
@@ -20,5 +20,11 @@ public class ConsentController implements ConsentControllerSwagger {
     @GetMapping
     public ResponseEntity<ResponseDTO> getConsents(@AuthenticationPrincipal MemberDTO memberDTO) {
         return ResponseUtil.createSuccessResponse(consentService.getConsentsInfo(memberDTO));
+    }
+
+    @PatchMapping
+    public ResponseEntity<ResponseDTO> updateConsent(@Valid @RequestBody ConsentUpdateRequestDTO updateRequestDTO, @AuthenticationPrincipal MemberDTO memberDTO) {
+        consentService.updateConsent(updateRequestDTO, memberDTO);
+        return ResponseUtil.createSuccessResponse(null);
     }
 }

--- a/src/main/java/com/codenear/butterfly/consent/presentation/ConsentControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/consent/presentation/ConsentControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.codenear.butterfly.consent.presentation;
 
 import com.codenear.butterfly.consent.dto.ConsentInfoResponseDTO;
+import com.codenear.butterfly.consent.dto.ConsentUpdateRequestDTO;
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,8 +10,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Consent", description = "**수신 동의 API**")
 public interface ConsentControllerSwagger {
@@ -22,4 +25,7 @@ public interface ConsentControllerSwagger {
             @ApiResponse(responseCode = "200", description = "Success")
     })
     ResponseEntity<ResponseDTO> getConsents(@AuthenticationPrincipal MemberDTO memberDTO);
+
+    @Operation(summary = "수신 동의 변경", description = "수신 동의 변경 API")
+    ResponseEntity<ResponseDTO> updateConsent(@Valid @RequestBody ConsentUpdateRequestDTO updateRequestDTO, @AuthenticationPrincipal MemberDTO memberDTO);
 }

--- a/src/main/java/com/codenear/butterfly/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codenear/butterfly/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.codenear.butterfly.global.exception;
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,6 +29,12 @@ public class GlobalExceptionHandler {
 
         log.warn(ERROR_MESSAGE, ex.getMessage(), ex);
         return createErrorResponse(ErrorCode.VALIDATION_FAILED, fieldError.getDefaultMessage(), filed);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ResponseDTO> notReadException(HttpMessageNotReadableException ex) {
+        log.warn(ERROR_MESSAGE, ex.getMessage(), ex);
+        return createErrorResponse(ErrorCode.VALIDATION_FAILED, null);
     }
 
     @ExceptionHandler(BusinessBaseException.class)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #199 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 마케팅 수신 동의 변경 기능 추가

## 🌄 이미지 첨부

![image](https://github.com/user-attachments/assets/2db814a1-a9aa-4ee7-bb80-ca32b56ef8cb)

## 🔧 앞으로의 과제

- 회원가입 시 자동으로 수신 동의 생성되게 끔
