### PR TITLE
223 유저 정보 저장 api 생성

### DIFF
--- a/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
+++ b/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     // 409 (CONFLICT)
     EMAIL_ALREADY_IN_USE(40900, "이메일이 중복되었습니다.", HttpStatus.CONFLICT),
     DUPLICATE_FAVORITE(40901, "이미 찜 목록에 추가된 상품입니다.", HttpStatus.CONFLICT),
+    NICKNAME_ALREADY_IN_USE(40902, "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
 
     // 500 (INTERNAL_SERVER_ERROR)
     SERVER_ERROR(500, "이용에 불편을 드려 죄송합니다. 현재 시스템 오류가 발생했습니다. 잠시 후 다시 시도 및 고객 문의 바랍니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/codenear/butterfly/member/application/NicknameService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/NicknameService.java
@@ -60,11 +60,7 @@ public class NicknameService {
     }
 
     private boolean isNicknameExists(String baseNickname) {
-        try {
-            return memberRepository.findMaxNumberedNickname(baseNickname).isPresent();
-        } catch (DataAccessException e) {
-            throw new MemberException(ErrorCode.SERVER_ERROR, baseNickname);
-        }
+        return memberRepository.findMaxNumberedNickname(baseNickname).isPresent();
     }
 
     private String generateBaseNickname() {

--- a/src/main/java/com/codenear/butterfly/member/application/NicknameService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/NicknameService.java
@@ -59,6 +59,11 @@ public class NicknameService {
         }
     }
 
+    private void validatorNicknameDuplication(String nickname) {
+        if (isNicknameExists(nickname))
+            throw new MemberException(ErrorCode.NICKNAME_ALREADY_IN_USE, null);
+    }
+
     private boolean isNicknameExists(String baseNickname) {
         return memberRepository.findMaxNumberedNickname(baseNickname).isPresent();
     }

--- a/src/main/java/com/codenear/butterfly/member/application/NicknameService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/NicknameService.java
@@ -1,21 +1,24 @@
 package com.codenear.butterfly.member.application;
 
 import com.codenear.butterfly.global.exception.ErrorCode;
+import com.codenear.butterfly.member.domain.Member;
 import com.codenear.butterfly.member.domain.dto.NicknameDTO;
 import com.codenear.butterfly.member.domain.repository.member.MemberRepository;
 import com.codenear.butterfly.member.exception.MemberException;
 import com.codenear.butterfly.member.util.NicknameList;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class NicknameService {
-
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     public NicknameDTO nicknameResponse() {
         String generatedNickname = generateNickname();
@@ -38,6 +41,14 @@ public class NicknameService {
         } catch (MemberException e) {
             throw new MemberException(ErrorCode.NICKNAME_GENERATION_FAILED, null);
         }
+    }
+
+    @CacheEvict(value = "userCache", key = "#memberId")
+    public void updateNickname(Long memberId, String newNickname) {
+        validatorNicknameDuplication(newNickname);
+
+        Member member = memberService.loadMemberByMemberId(memberId);
+        member.setNickname(newNickname);
     }
 
     private Optional<String> findMaxNumberedNickname(String baseNickname) {

--- a/src/main/java/com/codenear/butterfly/member/application/ProfileService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/ProfileService.java
@@ -1,0 +1,24 @@
+package com.codenear.butterfly.member.application;
+
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.member.domain.dto.ProfileUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProfileService {
+    private final NicknameService nicknameService;
+
+    public void updateMemberProfile(ProfileUpdateRequestDTO memberProfileRequestDTO, MemberDTO memberDTO) {
+        if (isNotNicknameEquals(memberProfileRequestDTO, memberDTO))
+            nicknameService.updateNickname(memberDTO.getId(), memberProfileRequestDTO.getNickname());
+
+    }
+
+    private boolean isNotNicknameEquals(ProfileUpdateRequestDTO memberProfileRequestDTO, MemberDTO memberDTO) {
+        return !memberProfileRequestDTO.getNickname().equals(memberDTO.getNickname());
+    }
+}

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -34,6 +34,7 @@ public class Member extends BaseEntity {
     private String password;
 
     @Column(nullable = false)
+    @Setter
     private String nickname;
 
     private String profileImage;

--- a/src/main/java/com/codenear/butterfly/member/domain/dto/ProfileUpdateRequestDTO.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/dto/ProfileUpdateRequestDTO.java
@@ -1,0 +1,16 @@
+package com.codenear.butterfly.member.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ProfileUpdateRequestDTO {
+    @Schema(description = "닉네임", example = "codenear")
+    @Size(min = 2, max = 8, message = "닉네임은 2자 ~ 8자 사이여야 합니다.")
+    @NotNull
+    private String nickname;
+
+    // 프로필 이미지
+}

--- a/src/main/java/com/codenear/butterfly/member/presentation/ProfileController.java
+++ b/src/main/java/com/codenear/butterfly/member/presentation/ProfileController.java
@@ -1,0 +1,30 @@
+package com.codenear.butterfly.member.presentation;
+
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.global.util.ResponseUtil;
+import com.codenear.butterfly.member.application.ProfileService;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.member.domain.dto.ProfileUpdateRequestDTO;
+import com.codenear.butterfly.member.presentation.swagger.ProfileControllerSwagger;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/member/profile")
+@RequiredArgsConstructor
+public class ProfileController implements ProfileControllerSwagger {
+    private final ProfileService profileService;
+
+    @PatchMapping
+    public ResponseEntity<ResponseDTO> updateMemberProfile(@Valid @RequestBody ProfileUpdateRequestDTO memberProfileRequestDTO,
+                                                           @AuthenticationPrincipal MemberDTO memberDTO) {
+        profileService.updateMemberProfile(memberProfileRequestDTO, memberDTO);
+        return ResponseUtil.createSuccessResponse(null);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/member/presentation/swagger/ProfileControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/member/presentation/swagger/ProfileControllerSwagger.java
@@ -1,0 +1,18 @@
+package com.codenear.butterfly.member.presentation.swagger;
+
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.member.domain.dto.ProfileUpdateRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Profile", description = "**프로필 API**")
+public interface ProfileControllerSwagger {
+
+    @Operation(summary = "유저 프로필 수정", description = "유저 프로필 수정 API")
+    public ResponseEntity<ResponseDTO> updateMemberProfile(@Valid @RequestBody ProfileUpdateRequestDTO memberProfileRequestDTO, @AuthenticationPrincipal MemberDTO memberDTO);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #220 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 유저 정보 수정하는 API 초안을 설계했습니다. (닉네임)

## 🌄 이미지 첨부 

<img width="1444" alt="image" src="https://github.com/user-attachments/assets/1d9b3e74-5a1f-42d8-83ee-ba1519b87e92">

## 🔧 앞으로의 과제

- 프로필 이미지 수정 기능을 만들 예정입니다.
