### PR TITLE
refactor(AddressService): 주소 상세 값 반환 변경 (#244)

### DIFF
--- a/src/main/java/com/codenear/butterfly/address/application/AddressService.java
+++ b/src/main/java/com/codenear/butterfly/address/application/AddressService.java
@@ -28,9 +28,6 @@ public class AddressService {
     public List<AddressResponseDTO> getAddresses(MemberDTO memberDTO) {
         LinkedList<Address> addresses = addressRepository.findAllByMemberId(memberDTO.getId());
 
-        if (addresses.isEmpty())
-            return null;
-
         moveMainAddress(addresses); // 메인 주소 가장 상단 배치
 
         return addresses.stream()
@@ -39,10 +36,11 @@ public class AddressService {
     }
 
     public AddressResponseDTO getAddress(Long addressId) {
-        Address address = addressRepository.findById(addressId)
-                .orElseThrow(() -> new AddressException(ErrorCode.SERVER_ERROR, null));
+        Optional<Address> optAddress = addressRepository.findById(addressId);
 
-        return convertToAddressResponseDTO(address);
+        return optAddress
+                .map(this::convertToAddressResponseDTO)
+                .orElse(null);
     }
 
     public AddressAddResponseDTO createAddress(AddressCreateDTO addressCreateDTO, MemberDTO memberDTO) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #243
 
## 🔘 Part

- [x] BE

## 🔎 작업 내용

- FE측 요청으로 상세 주소 검색 시 데이터가 없을 경우 Null 의 성공 요청 반환을 위해 로직 변경했습니다.

- 기존에 잘못 이해했던 전체의 Null 반환을 Rollback 했습니다.
