### PR TITLE
290 fix s3 프로필 이미지 미삭제 버그

### DIFF
--- a/src/main/java/com/codenear/butterfly/member/application/MemberService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/MemberService.java
@@ -1,12 +1,15 @@
 package com.codenear.butterfly.member.application;
 
-import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import static com.codenear.butterfly.s3.domain.S3Directory.PROFILE_IMAGE;
+
 import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import com.codenear.butterfly.member.domain.dto.MemberInfoDTO;
 import com.codenear.butterfly.member.domain.repository.member.MemberRepository;
 import com.codenear.butterfly.member.exception.MemberException;
 import com.codenear.butterfly.point.application.PointService;
+import com.codenear.butterfly.s3.application.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -19,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PointService pointService;
+    private final S3Service s3Service;
 
     public MemberInfoDTO getMemberInfo(MemberDTO memberDTO) {
         Integer pointValue = pointService.loadPointByMemberId(memberDTO.getId()).getPoint();
@@ -27,7 +31,7 @@ public class MemberService {
                 memberDTO.getEmail(),
                 memberDTO.getPhoneNumber(),
                 memberDTO.getNickname(),
-                memberDTO.getProfileImage(),
+                s3Service.generateFileUrl(memberDTO.getProfileImage(), PROFILE_IMAGE),
                 0, // TODO : 추후 쿠폰 시스템 도입 후 수정
                 memberDTO.getGrade().getGrade(),
                 pointValue

--- a/src/main/java/com/codenear/butterfly/member/application/ProfileService.java
+++ b/src/main/java/com/codenear/butterfly/member/application/ProfileService.java
@@ -1,11 +1,11 @@
 package com.codenear.butterfly.member.application;
 
 import static com.codenear.butterfly.member.util.ImageResizeUtil.resizeImage;
+import static com.codenear.butterfly.s3.domain.S3Directory.PROFILE_IMAGE;
 
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import com.codenear.butterfly.member.domain.dto.ProfileUpdateRequestDTO;
 import com.codenear.butterfly.s3.application.S3Service;
-import com.codenear.butterfly.s3.domain.S3Directory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,12 +40,12 @@ public class ProfileService {
 
     private void deleteExistingProfileImage(MemberDTO memberDTO) {
         if (memberDTO.getProfileImage() != null) {
-            s3Service.deleteFile(memberDTO.getProfileImage());
+            s3Service.deleteFile(memberDTO.getProfileImage(), PROFILE_IMAGE);
         }
     }
 
     private String uploadNewProfileImage(MultipartFile profileImage) {
         MultipartFile resized = resizeImage(profileImage); // 이미지 리사이즈
-        return s3Service.uploadFile(resized, S3Directory.PROFILE_IMAGE);
+        return s3Service.uploadFile(resized, PROFILE_IMAGE);
     }
 }

--- a/src/main/java/com/codenear/butterfly/s3/application/S3Service.java
+++ b/src/main/java/com/codenear/butterfly/s3/application/S3Service.java
@@ -1,51 +1,59 @@
 package com.codenear.butterfly.s3.application;
 
+import static java.util.UUID.randomUUID;
+import static software.amazon.awssdk.services.s3.model.ObjectCannedACL.PUBLIC_READ;
+
 import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.s3.domain.S3Directory;
 import com.codenear.butterfly.s3.exception.S3Exception;
-import java.net.URL;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetUrlRequest;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class S3Service {
-    private final S3Client amazonS3Client;
 
     private static final String BUKKIT_NAME = "codenear";
 
+    private final S3Client amazonS3Client;
+
+    @Value("${cloud.storage.url}")
+    private String storageUrl;
+
     public String uploadFile(MultipartFile file, S3Directory directory) {
         try {
-            String fileKey = createFileKey(directory, file.getOriginalFilename());
+            String fileName = generateFileName();
+            String fileKey = generateFileKey(fileName, directory);
             String contentType = file.getContentType();
 
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(BUKKIT_NAME)
                     .key(fileKey)
                     .contentType(contentType)
-                    .acl(ObjectCannedACL.PUBLIC_READ)
+                    .acl(PUBLIC_READ)
                     .build();
 
             RequestBody requestBody = RequestBody.fromInputStream(file.getInputStream(), file.getSize());
             amazonS3Client.putObject(putObjectRequest, requestBody);
 
-            return generateFileUrl(fileKey);
+            return fileName;
         } catch (Exception e) {
             throw new S3Exception(ErrorCode.SERVER_ERROR, null);
         }
     }
 
-    public void deleteFile(String fileKey) {
+    public String generateFileUrl(String fileName, S3Directory directory) {
+        return storageUrl + directory.getValue() + fileName;
+    }
+
+    public void deleteFile(String fileName, S3Directory directory) {
+        String fileKey = generateFileKey(fileName, directory);
         DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                 .bucket(BUKKIT_NAME)
                 .key(fileKey)
@@ -54,18 +62,13 @@ public class S3Service {
         amazonS3Client.deleteObject(deleteObjectRequest);
     }
 
-    private String generateFileUrl(String fileKey) {
-        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
-                .bucket(BUKKIT_NAME)
-                .key(fileKey)
-                .build();
-
-        URL url = amazonS3Client.utilities().getUrl(getUrlRequest);
-        return url.toString();
+    private String generateFileName() {
+        String uniqueId = randomUUID().toString();
+        long currentTimeMillis = System.currentTimeMillis();
+        return uniqueId + currentTimeMillis;
     }
 
-    private String createFileKey(S3Directory directory, String originalFilename) {
-        String uniqueId = UUID.randomUUID().toString();
-        return directory.getValue() + uniqueId + originalFilename;
+    private String generateFileKey(String fileName, S3Directory directory) {
+        return directory.getValue() + fileName;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #290 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 프로필 이미지가 이미 존재할 경우 교체할 때, 기존의 이미지를 삭제하는 과정의 오류가 발생했습니다. 이를 수정하기 위해 방식을 변경했습니다.

## 🔧 앞으로의 과제

- S3 리팩토링 필요
