### PR TITLE
317 클라이언트 → 서버 토큰 전달 및 저장 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'net.nurigo:sdk:4.3.0'
 	implementation 'net.coobird:thumbnailator:0.4.20'
+	implementation 'com.google.firebase:firebase-admin:9.4.1'
 
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/com/codenear/butterfly/consent/application/ConsentFacade.java
+++ b/src/main/java/com/codenear/butterfly/consent/application/ConsentFacade.java
@@ -1,0 +1,17 @@
+package com.codenear.butterfly.consent.application;
+
+import com.codenear.butterfly.consent.domain.Consent;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ConsentFacade {
+
+    private final ConsentService consentService;
+
+    public List<Consent> getConsentByMemberId(Long id) {
+        return consentService.loadConsentsByMemberId(id);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
+++ b/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
@@ -47,11 +47,11 @@ public class ConsentService {
                 .orElse(false);
     }
 
-    private  ConsentSingleResponseDTO createConsentSingleResponseDTO(ConsentType value, boolean agreed) {
+    private ConsentSingleResponseDTO createConsentSingleResponseDTO(ConsentType value, boolean agreed) {
         return new ConsentSingleResponseDTO(value, agreed);
     }
 
-    public List<Consent> loadConsentsByMemberId(Long id) {
+    protected List<Consent> loadConsentsByMemberId(Long id) {
         return consentRepository.findByMemberId(id);
     }
 

--- a/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
+++ b/src/main/java/com/codenear/butterfly/consent/application/ConsentService.java
@@ -24,7 +24,7 @@ public class ConsentService {
     private final MemberService memberService;
 
     public ConsentInfoResponseDTO getConsentsInfo(MemberDTO memberDTO) {
-        List<Consent> consents = loadConsentsByMemberId(memberDTO);
+        List<Consent> consents = loadConsentsByMemberId(memberDTO.getId());
         List<ConsentSingleResponseDTO> consentSingleDTOS = getConsentSingleResponseDTOS(consents);
         return new ConsentInfoResponseDTO(consentSingleDTOS);
     }
@@ -51,12 +51,12 @@ public class ConsentService {
         return new ConsentSingleResponseDTO(value, agreed);
     }
 
-    private List<Consent> loadConsentsByMemberId(MemberDTO memberDTO) {
-        return consentRepository.findByMemberId(memberDTO.getId());
+    public List<Consent> loadConsentsByMemberId(Long id) {
+        return consentRepository.findByMemberId(id);
     }
 
     public void updateConsent(ConsentUpdateRequestDTO updateRequestDTO, MemberDTO memberDTO) {
-        List<Consent> consents = loadConsentsByMemberId(memberDTO);
+        List<Consent> consents = loadConsentsByMemberId(memberDTO.getId());
         ConsentType type = updateRequestDTO.getConsentType();
 
         Consent consent = consents.stream()

--- a/src/main/java/com/codenear/butterfly/consent/domain/ConsentType.java
+++ b/src/main/java/com/codenear/butterfly/consent/domain/ConsentType.java
@@ -1,6 +1,14 @@
 package com.codenear.butterfly.consent.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ConsentType {
-    MARKETING,
-    DELIVERY_NOTIFICATION
+    MARKETING("marketing"),
+    DELIVERY_NOTIFICATION("deliveryNotification");
+
+    private final String topic;
 }

--- a/src/main/java/com/codenear/butterfly/fcm/application/FCMFacade.java
+++ b/src/main/java/com/codenear/butterfly/fcm/application/FCMFacade.java
@@ -1,0 +1,16 @@
+package com.codenear.butterfly.fcm.application;
+
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FCMFacade {
+
+    private final FCMService fcmService;
+
+    public void saveFCM(String token, MemberDTO loginMember) {
+        fcmService.saveFCM(token, loginMember);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/fcm/application/FCMService.java
+++ b/src/main/java/com/codenear/butterfly/fcm/application/FCMService.java
@@ -4,7 +4,9 @@ import com.codenear.butterfly.consent.application.ConsentFacade;
 import com.codenear.butterfly.consent.domain.Consent;
 import com.codenear.butterfly.fcm.domain.FCM;
 import com.codenear.butterfly.fcm.domain.FCMRepository;
+import com.codenear.butterfly.member.application.MemberFacade;
 import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import java.time.LocalDateTime;
@@ -18,13 +20,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class FCMService {
 
     private final ConsentFacade consentFacade;
+    private final MemberFacade memberFacade;
     private final FCMRepository fcmRepository;
     private final FirebaseMessaging firebaseMessaging;
 
     @Transactional
-    protected void saveFCM(String token, Member member) {
-        createAndSaveFCM(token, member);
+    protected void saveFCM(String token, MemberDTO loginMember) {
+        Member member = memberFacade.getMember(loginMember.getId());
         List<Consent> consents = consentFacade.getConsentByMemberId(member.getId());
+
+        createAndSaveFCM(token, member);
         subscribeToConsentedTopics(token, consents);
     }
 

--- a/src/main/java/com/codenear/butterfly/fcm/application/FCMService.java
+++ b/src/main/java/com/codenear/butterfly/fcm/application/FCMService.java
@@ -1,0 +1,65 @@
+package com.codenear.butterfly.fcm.application;
+
+import com.codenear.butterfly.consent.application.ConsentFacade;
+import com.codenear.butterfly.consent.domain.Consent;
+import com.codenear.butterfly.fcm.domain.FCM;
+import com.codenear.butterfly.fcm.domain.FCMRepository;
+import com.codenear.butterfly.member.domain.Member;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FCMService {
+
+    private final ConsentFacade consentFacade;
+    private final FCMRepository fcmRepository;
+    private final FirebaseMessaging firebaseMessaging;
+
+    @Transactional
+    protected void saveFCM(String token, Member member) {
+        createAndSaveFCM(token, member);
+        List<Consent> consents = consentFacade.getConsentByMemberId(member.getId());
+        subscribeToConsentedTopics(token, consents);
+    }
+
+    private void createAndSaveFCM(String token, Member member) {
+        FCM fcm = FCM.builder()
+                .member(member)
+                .token(token)
+                .lastUsedDate(LocalDateTime.now())
+                .build();
+        fcmRepository.save(fcm);
+    }
+
+    private void subscribeToConsentedTopics(String token, List<Consent> consents) {
+        List<String> tokens = List.of(token);
+        consents.stream()
+                .filter(Consent::isAgreed)
+                .forEach(consent -> {
+                    String topic = consent.getConsentType().getTopic();
+                    subscribeToTopic(tokens, topic);
+                });
+    }
+
+    private void subscribeToTopic(List<String> tokens, String topic) {
+        try {
+            firebaseMessaging.subscribeToTopic(tokens, topic);
+        } catch (FirebaseMessagingException e) {
+            // 에러 처리 해야함
+        }
+    }
+
+    private void unsubscribeFromTopic(List<String> tokens, String topic) {
+        try {
+            firebaseMessaging.unsubscribeFromTopic(tokens, topic);
+        } catch (FirebaseMessagingException e) {
+            // 에러 처리 해야함
+        }
+    }
+}

--- a/src/main/java/com/codenear/butterfly/fcm/config/FirebaseConfig.java
+++ b/src/main/java/com/codenear/butterfly/fcm/config/FirebaseConfig.java
@@ -1,0 +1,42 @@
+package com.codenear.butterfly.fcm.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.IOException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class FirebaseConfig {
+
+    private static final String FIREBASE_CONFIG_PATH = "firebase/firebase-service-account.json";
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        GoogleCredentials credentials = loadGoogleCredentials();
+        FirebaseOptions options = createFirebaseOptions(credentials);
+        FirebaseApp app = createFirebaseApp(options);
+
+        return FirebaseMessaging.getInstance(app);
+    }
+
+    private GoogleCredentials loadGoogleCredentials() throws IOException {
+        return GoogleCredentials.fromStream(new ClassPathResource(FIREBASE_CONFIG_PATH).getInputStream());
+    }
+
+    private FirebaseOptions createFirebaseOptions(GoogleCredentials credentials) {
+        return FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .build();
+    }
+
+    private FirebaseApp createFirebaseApp(FirebaseOptions options) {
+        if (FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.initializeApp(options);
+        }
+        return FirebaseApp.getInstance();
+    }
+}

--- a/src/main/java/com/codenear/butterfly/fcm/domain/FCM.java
+++ b/src/main/java/com/codenear/butterfly/fcm/domain/FCM.java
@@ -1,0 +1,39 @@
+package com.codenear.butterfly.fcm.domain;
+
+import com.codenear.butterfly.global.domain.BaseEntity;
+import com.codenear.butterfly.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class FCM {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private String token;
+
+    private LocalDateTime lastUsedDate;
+}

--- a/src/main/java/com/codenear/butterfly/fcm/domain/FCMRepository.java
+++ b/src/main/java/com/codenear/butterfly/fcm/domain/FCMRepository.java
@@ -1,0 +1,8 @@
+package com.codenear.butterfly.fcm.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FCMRepository extends JpaRepository<FCM, Long> {
+}

--- a/src/main/java/com/codenear/butterfly/fcm/presentation/FCMController.java
+++ b/src/main/java/com/codenear/butterfly/fcm/presentation/FCMController.java
@@ -1,0 +1,28 @@
+package com.codenear.butterfly.fcm.presentation;
+
+import com.codenear.butterfly.fcm.application.FCMFacade;
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.global.util.ResponseUtil;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/FCM")
+public class FCMController {
+
+    private final FCMFacade fcmFacade;
+
+    @PostMapping("/{token}")
+    public ResponseEntity<ResponseDTO> registerFcm(@PathVariable String token,
+                                                   @AuthenticationPrincipal MemberDTO memberDTO) {
+        fcmFacade.saveFCM(token, memberDTO);
+        return ResponseUtil.createSuccessResponse(null);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/fcm/presentation/FCMController.java
+++ b/src/main/java/com/codenear/butterfly/fcm/presentation/FCMController.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/FCM")
-public class FCMController {
+@RequestMapping("/fcm")
+public class FCMController implements FCMControllerSwagger {
 
     private final FCMFacade fcmFacade;
 
     @PostMapping("/{token}")
-    public ResponseEntity<ResponseDTO> registerFcm(@PathVariable String token,
+    public ResponseEntity<ResponseDTO> registerFCM(@PathVariable String token,
                                                    @AuthenticationPrincipal MemberDTO memberDTO) {
         fcmFacade.saveFCM(token, memberDTO);
         return ResponseUtil.createSuccessResponse(null);

--- a/src/main/java/com/codenear/butterfly/fcm/presentation/FCMControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/fcm/presentation/FCMControllerSwagger.java
@@ -1,0 +1,16 @@
+package com.codenear.butterfly.fcm.presentation;
+
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "FCM", description = "**FCM API**")
+public interface FCMControllerSwagger {
+
+    @Operation(summary = "토큰 등록", description = "토큰 등록 API (로그인 과정에 **필수 등록**)")
+    ResponseEntity<ResponseDTO> registerFCM(@PathVariable String token, @AuthenticationPrincipal MemberDTO memberDTO);
+}

--- a/src/main/java/com/codenear/butterfly/global/config/SwaggerConfig.java
+++ b/src/main/java/com/codenear/butterfly/global/config/SwaggerConfig.java
@@ -40,7 +40,7 @@ public class SwaggerConfig {
     public List<GroupedOpenApi> apis() {
         return List.of(
             createGroupedOpenApi("회원가입, 로그인 API", "/auth/**", "/oauth/**", "/logout"),
-            createGroupedOpenApi("유저 API", "/member/**","/certify/**" ),
+            createGroupedOpenApi("유저 API", "/member/**","/certify/**","/fcm/**"),
             createGroupedOpenApi("상품 API", "/products/**"),
             createGroupedOpenApi("고객 문의 API", "/support/**"),
             createGroupedOpenApi("검색 API", "/search/**"),

--- a/src/main/java/com/codenear/butterfly/member/application/MemberFacade.java
+++ b/src/main/java/com/codenear/butterfly/member/application/MemberFacade.java
@@ -1,0 +1,16 @@
+package com.codenear.butterfly.member.application;
+
+import com.codenear.butterfly.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberFacade {
+
+    private final MemberService memberService;
+
+    public Member getMember(Long id) {
+        return memberService.loadMemberByMemberId(id);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #316 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 서버에 토큰을 전달해 유저와 매핑해서 보관하는 기능 구현했습니다.
- 토큰 전달로 현재 동의 여부를 파악한 후 Topic 에 저장할 수 있도록 구현했습니다.

## 🌄 이미지 첨부

![image](https://github.com/user-attachments/assets/71e1384f-083f-4aec-85df-37e29b04ccfe)
