### PR TITLE
348 주문 내역 저장 시 주소 저장 방식 변경

### DIFF
--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -133,7 +133,8 @@ public class SinglePaymentService {
         } else if (OrderType.DELIVER.getType().equals(orderType.getType())) {
             Address address = addressRepository.findById(addressId)
                     .orElseThrow(() -> new KakaoPayException(ErrorCode.ADDRESS_NOT_FOUND, null));
-            orderDetails.setAddress(address);
+            orderDetails.setAddress(address.getAddress());
+            orderDetails.setDetailedAddress(address.getDetailedAddress());
         }
 
         orderDetails.setTotal(approveResponseDTO.getAmount().getTotal());

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/OrderDetails.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/OrderDetails.java
@@ -40,9 +40,8 @@ public class OrderDetails {
     private LocalTime pickupTime;
 
     // 배달 시
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "address_id")
-    private Address address;
+    private String address;
+    private String detailedAddress;
     private LocalDate deliverDate;
 
     private String productName;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #348 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 주소와 1대1 관계 매핑했던 것을 주소와 상세주소 컬럼을 추가하여 단순 정보만 저장하게 로직을 수정하였습니다.