### PR TITLE
352 프로모션 적용 가능 여부 확인 기능

### DIFF
--- a/src/main/java/com/codenear/butterfly/promotion/domain/PointPromotion.java
+++ b/src/main/java/com/codenear/butterfly/promotion/domain/PointPromotion.java
@@ -1,0 +1,16 @@
+package com.codenear.butterfly.promotion.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import java.math.BigDecimal;
+
+@Entity
+@DiscriminatorValue("POINT")
+public class PointPromotion extends Promotion {
+
+    private BigDecimal rewardAmount;
+
+    private int usedAmount; // 프로모션 지급한 금액
+
+    private int totalAmount; // 프로모션 최대 한도 금액
+}

--- a/src/main/java/com/codenear/butterfly/promotion/domain/PointPromotion.java
+++ b/src/main/java/com/codenear/butterfly/promotion/domain/PointPromotion.java
@@ -2,15 +2,34 @@ package com.codenear.butterfly.promotion.domain;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("POINT")
 public class PointPromotion extends Promotion {
 
+    @NotNull
+    @DecimalMin("0.0")
     private BigDecimal rewardAmount;
 
+    @NotNull
     private int usedAmount; // 프로모션 지급한 금액
 
+    @NotNull
     private int totalAmount; // 프로모션 최대 한도 금액
+
+    @Override
+    public boolean isApplicable() {
+        int remainedAmount = totalAmount - usedAmount;
+        return remainedAmount >= rewardAmount.intValue();
+    }
 }

--- a/src/main/java/com/codenear/butterfly/promotion/domain/Promotion.java
+++ b/src/main/java/com/codenear/butterfly/promotion/domain/Promotion.java
@@ -1,0 +1,27 @@
+package com.codenear.butterfly.promotion.domain;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import java.time.LocalDate;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+public class Promotion {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private boolean active;
+}

--- a/src/main/java/com/codenear/butterfly/promotion/domain/Promotion.java
+++ b/src/main/java/com/codenear/butterfly/promotion/domain/Promotion.java
@@ -12,11 +12,11 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
-@Builder
+@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/src/main/java/com/codenear/butterfly/promotion/domain/Promotion.java
+++ b/src/main/java/com/codenear/butterfly/promotion/domain/Promotion.java
@@ -2,26 +2,49 @@ package com.codenear.butterfly.promotion.domain;
 
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type")
 public class Promotion {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotBlank
     private String name;
 
     private String description;
 
+    @NotNull
     private LocalDate startDate;
 
+    @NotNull
     private LocalDate endDate;
 
     private boolean active;
+
+    public boolean isApplicable() {
+        LocalDate now = LocalDate.now();
+        if (startDate.isAfter(now) || endDate.isBefore(now)) {
+            return false;
+        }
+        return active;
+    }
 }

--- a/src/test/java/com/codenear/butterfly/promotion/domain/PointPromotionTest.java
+++ b/src/test/java/com/codenear/butterfly/promotion/domain/PointPromotionTest.java
@@ -1,0 +1,39 @@
+package com.codenear.butterfly.promotion.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PointPromotionTest {
+
+    @ParameterizedTest(name = "지급 포인트: {0}, 현재 지급 상황: {1}, 최대 지급 포인트: {2}, 예상 결과: {3}")
+    @CsvSource({
+        "100, 200, 500, true",
+        "100, 400, 500, true",
+        "100, 450, 500, false",
+        "100, 500, 500, false"
+    })
+    void 포인트_프로모션의_가능_여부를_테스트한다(BigDecimal reward, int used, int total, boolean expected) {
+        // given
+        PointPromotion pointPromotion = createPointPromotion(reward, used, total);
+
+        // when
+        boolean result = pointPromotion.isApplicable();
+
+        // then
+        assertThat(result)
+                .isEqualTo(expected);
+    }
+
+    private PointPromotion createPointPromotion(BigDecimal reward, int used, int total) {
+        return PointPromotion.builder()
+                .self()
+                .rewardAmount(reward)
+                .usedAmount(used)
+                .totalAmount(total)
+                .build();
+    }
+
+}

--- a/src/test/java/com/codenear/butterfly/promotion/domain/PromotionTest.java
+++ b/src/test/java/com/codenear/butterfly/promotion/domain/PromotionTest.java
@@ -1,0 +1,56 @@
+package com.codenear.butterfly.promotion.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class PromotionTest {
+
+    @Test
+    void 프로모션_기간이_아닌_경우_FALSE를_반환한다() {
+        // given
+        Promotion promotion = createPromotion(LocalDate.MAX, true);
+
+        // when
+        boolean result = promotion.isApplicable();
+
+        // then
+        assertThat(result)
+                .isFalse();
+    }
+
+    @Test
+    void 프로모션_기간인_경우_TRUE를_반환한다() {
+        // given
+        Promotion promotion = createPromotion(LocalDate.MIN, true);
+
+        // when
+        boolean result = promotion.isApplicable();
+
+        // then
+        assertThat(result)
+                .isTrue();
+    }
+
+    @Test
+    void 프로모션_비활성화_경우_FALSE를_반환한다() {
+        // given
+        Promotion promotion = createPromotion(LocalDate.MIN, false);
+
+        // when
+        boolean result = promotion.isApplicable();
+
+        // then
+        assertThat(result)
+                .isFalse();
+    }
+
+    private Promotion createPromotion(LocalDate startDate, boolean active) {
+        return Promotion.builder()
+                .startDate(startDate)
+                .endDate(LocalDate.MAX)
+                .active(active)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #351 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 프로모션 적용 가능 여부와 두 엔티티를 새로 정의했습니다.

## 🔧 앞으로의 과제

- 프로모션 지급 목록 엔티티와 중복 처리 로직을 구현할 예정입니다.
