### PR TITLE
399 refactor 카카오 페이 단건결제 코드 리팩토링

### DIFF
--- a/src/main/java/com/codenear/butterfly/admin/order/application/AdminOrderDetailsService.java
+++ b/src/main/java/com/codenear/butterfly/admin/order/application/AdminOrderDetailsService.java
@@ -29,7 +29,7 @@ public class AdminOrderDetailsService {
         OrderDetails order = orderDetailsRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND, ErrorCode.ORDER_NOT_FOUND.getMessage()));
 
-        order.setOrderStatus(newStatus);
+        order.updateOrderStatus(newStatus);
         orderDetailsRepository.save(order);
     }
 }

--- a/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
+++ b/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
@@ -5,7 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.PAYMENT_REQUIRED;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -31,7 +37,7 @@ public enum ErrorCode {
     BLACKLIST_JWT_REFRESH_TOKEN(40101, "(Refresh) 사용이 금지된 토큰입니다.", UNAUTHORIZED),
 
     // 402 (PAYMENT_REQUIRED)
-    PAY_FAILED(40200,"결제가 실패하였습니다.", PAYMENT_REQUIRED),
+    PAY_FAILED(40200, "결제가 실패하였습니다.", PAYMENT_REQUIRED),
 
     // 403 (FORBIDDEN)
     INVALID_EMAIL_OR_PASSWORD(40300, "아이디 혹은 비밀번호가 틀렸습니다.", FORBIDDEN),

--- a/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
+++ b/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
@@ -1,11 +1,11 @@
 package com.codenear.butterfly.global.exception;
 
-import static org.springframework.http.HttpStatus.*;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,6 +19,7 @@ public enum ErrorCode {
     CERTIFY_CODE_EXPIRED(40005, "인증 번호 입력 시간이 초과되었습니다. 다시 시도해 주세요.", BAD_REQUEST),
     FILE_SIZE_LIMIT_EXCEEDED(40006, "업로드 파일 크기가 초과되었습니다.", BAD_REQUEST),
     INSUFFICIENT_STOCK(40007, "해당 상품의 재고가 부족합니다.", BAD_REQUEST),
+    INVALID_PAYMENT_METHOD(40008, "해당 결제 수단을 사용할 수 없습니다.", BAD_REQUEST),
 
     // 401 (UNAUTHORIZED)
     NULL_JWT_ACCESS_TOKEN(40100, "(Access) 토큰이 존재하지 않습니다.", UNAUTHORIZED),

--- a/src/main/java/com/codenear/butterfly/global/util/HashMapUtil.java
+++ b/src/main/java/com/codenear/butterfly/global/util/HashMapUtil.java
@@ -1,0 +1,16 @@
+package com.codenear.butterfly.global.util;
+
+
+import java.util.HashMap;
+
+public class HashMapUtil<K,V> extends HashMap<K, V> {
+
+    // value에 값이 null이라면 맵에 넣지 않는다
+    @Override
+    public V put(K key, V value) {
+        if(value != null){
+            return super.put(key, value);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/codenear/butterfly/global/util/HashMapUtil.java
+++ b/src/main/java/com/codenear/butterfly/global/util/HashMapUtil.java
@@ -1,14 +1,13 @@
 package com.codenear.butterfly.global.util;
 
-
 import java.util.HashMap;
 
-public class HashMapUtil<K,V> extends HashMap<K, V> {
+public class HashMapUtil<K, V> extends HashMap<K, V> {
 
     // value에 값이 null이라면 맵에 넣지 않는다
     @Override
     public V put(K key, V value) {
-        if(value != null){
+        if (value != null) {
             return super.put(key, value);
         }
         return null;

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
@@ -4,19 +4,15 @@ import com.codenear.butterfly.kakaoPay.domain.CancelPayment;
 import com.codenear.butterfly.kakaoPay.domain.CanceledAmount;
 import com.codenear.butterfly.kakaoPay.domain.OrderDetails;
 import com.codenear.butterfly.kakaoPay.domain.dto.OrderStatus;
-import com.codenear.butterfly.kakaoPay.domain.dto.request.CancelRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.kakao.CancelResponseDTO;
+import com.codenear.butterfly.kakaoPay.domain.dto.request.CancelRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.repository.CancelPaymentRepository;
 import com.codenear.butterfly.kakaoPay.domain.repository.OrderDetailsRepository;
+import com.codenear.butterfly.kakaoPay.util.KakaoPaymentUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -24,36 +20,17 @@ import java.util.Objects;
 @Transactional
 @RequiredArgsConstructor
 public class CancelPaymentService {
-
-    @Value("${kakao.payment.cid}")
-    private String CID;
-
-    @Value("${kakao.payment.secret-key-dev}")
-    private String secretKey;
-
-    @Value("${kakao.payment.host}")
-    private String host;
-
     private final CancelPaymentRepository cancelPaymentRepository;
     private final OrderDetailsRepository orderDetailsRepository;
+    private final KakaoPaymentUtil<Object> kakaoPaymentUtil;
 
     public void cancelKakaoPay(CancelRequestDTO cancelRequestDTO) {
 
         OrderDetails orderDetails = orderDetailsRepository.findByOrderCode(cancelRequestDTO.getOrderCode());
 
-        Map<String, Object> parameters = new HashMap<>();
-        parameters.put("cid", CID);
-        parameters.put("tid", orderDetails.getTid());
-        parameters.put("cancel_amount", cancelRequestDTO.getCancelAmount());
-        parameters.put("cancel_tax_free_amount", 0);
+        Map<String, Object> parameters = kakaoPaymentUtil.getKakaoPayCancelParameters(orderDetails,cancelRequestDTO);
 
-        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(parameters, this.getHeaders());
-        RestTemplate restTemplate = new RestTemplate();
-
-        CancelResponseDTO cancelResponseDTO = restTemplate.postForObject(
-                host+"/cancel",
-                requestEntity,
-                CancelResponseDTO.class);
+        CancelResponseDTO cancelResponseDTO = kakaoPaymentUtil.sendRequest("/cancel",parameters,CancelResponseDTO.class);
 
         CancelPayment cancelPayment = createCancelPayment(cancelResponseDTO);
 
@@ -90,13 +67,5 @@ public class CancelPaymentService {
         canceledAmount.setPoint(cancelResponseDTO.getAmount().getPoint());
         canceledAmount.setDiscount(cancelResponseDTO.getAmount().getDiscount());
         return canceledAmount;
-    }
-
-    // 카카오가 요구한 헤더값
-    private HttpHeaders getHeaders() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Content-Type", "application/json");
-        headers.set("Authorization", "SECRET_KEY " + secretKey);
-        return headers;
     }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
@@ -60,7 +60,7 @@ public class CancelPaymentService {
         CanceledAmount canceledAmount = createApprovedCancelAmount(cancelResponseDTO);
         cancelPayment.setCanceledAmount(canceledAmount);
 
-        orderDetails.setOrderStatus(OrderStatus.CANCELED);
+        orderDetails.updateOrderStatus(OrderStatus.CANCELED);
         cancelPaymentRepository.save(cancelPayment);
     }
 

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
-import java.util.Objects;
 
 @Service
 @Transactional
@@ -32,40 +31,12 @@ public class CancelPaymentService {
 
         CancelResponseDTO cancelResponseDTO = kakaoPaymentUtil.sendRequest("/cancel",parameters,CancelResponseDTO.class);
 
-        CancelPayment cancelPayment = createCancelPayment(cancelResponseDTO);
+        CancelPayment cancelPayment = CancelPayment.builder().cancelResponseDTO(cancelResponseDTO).build();
 
-        CanceledAmount canceledAmount = createApprovedCancelAmount(cancelResponseDTO);
-        cancelPayment.setCanceledAmount(canceledAmount);
+        CanceledAmount canceledAmount = CanceledAmount.builder().cancelResponseDTO(cancelResponseDTO).build();
+        cancelPayment.addCanceledAmount(canceledAmount);
 
         orderDetails.updateOrderStatus(OrderStatus.CANCELED);
         cancelPaymentRepository.save(cancelPayment);
-    }
-
-    private CancelPayment createCancelPayment(CancelResponseDTO cancelResponseDTO) {
-        CancelPayment cancelPayment = new CancelPayment();
-        cancelPayment.setAid(Objects.requireNonNull(cancelResponseDTO).getAid());
-        cancelPayment.setTid(cancelResponseDTO.getTid());
-        cancelPayment.setCid(cancelResponseDTO.getCid());
-        cancelPayment.setStatus(cancelResponseDTO.getStatus());
-        cancelPayment.setPartnerOrderId(cancelResponseDTO.getPartner_order_id());
-        cancelPayment.setPartnerUserId(cancelResponseDTO.getPartner_user_id());
-        cancelPayment.setPaymentMethodType(cancelResponseDTO.getPayment_method_type());
-        cancelPayment.setItemName(cancelResponseDTO.getItem_name());
-        cancelPayment.setItemCode(cancelResponseDTO.getItem_code());
-        cancelPayment.setQuantity(cancelResponseDTO.getQuantity());
-        cancelPayment.setCreatedAt(cancelResponseDTO.getCreated_at());
-        cancelPayment.setApprovedAt(cancelResponseDTO.getApproved_at());
-        cancelPayment.setPayload(cancelResponseDTO.getPayload());
-        return cancelPayment;
-    }
-
-    private CanceledAmount createApprovedCancelAmount(CancelResponseDTO cancelResponseDTO) {
-        CanceledAmount canceledAmount = new CanceledAmount();
-        canceledAmount.setTotal(Objects.requireNonNull(cancelResponseDTO).getAmount().getTotal());
-        canceledAmount.setTaxFree(cancelResponseDTO.getAmount().getTax_free());
-        canceledAmount.setVat(cancelResponseDTO.getAmount().getVat());
-        canceledAmount.setPoint(cancelResponseDTO.getAmount().getPoint());
-        canceledAmount.setDiscount(cancelResponseDTO.getAmount().getDiscount());
-        return canceledAmount;
     }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -128,8 +128,8 @@ public class SinglePaymentService {
         product.increasePurchaseParticipantCount(quantity);
 
         SinglePayment singlePayment = SinglePayment.builder().approveResponseDTO(approveResponseDTO).build();
-        Amount amount = createAmount(approveResponseDTO);
-        singlePayment.setAmount(amount);
+        Amount amount = Amount.builder().approveResponseDTO(approveResponseDTO).build();
+        singlePayment.addAmount(amount);
 
         if (Objects.requireNonNull(approveResponseDTO).getPayment_method_type().equals("CARD")) {
             CardInfo cardInfo = createCardInfo(approveResponseDTO);
@@ -211,16 +211,6 @@ public class SinglePaymentService {
         } else if (status.equals(PaymentStatus.SUCCESS.name())) {
             kakaoPaymentRedisRepository.removePaymentStatus(key);
         }
-    }
-
-    private Amount createAmount(ApproveResponseDTO approveResponseDTO) {
-        Amount amount = new Amount();
-        amount.setTotal(Objects.requireNonNull(approveResponseDTO).getAmount().getTotal());
-        amount.setTaxFree(approveResponseDTO.getAmount().getTax_free());
-        amount.setVat(approveResponseDTO.getAmount().getVat());
-        amount.setPoint(approveResponseDTO.getAmount().getPoint());
-        amount.setDiscount(approveResponseDTO.getAmount().getDiscount());
-        return amount;
     }
 
     private CardInfo createCardInfo(ApproveResponseDTO approveResponseDTO) {

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -132,8 +132,8 @@ public class SinglePaymentService {
         singlePayment.addAmount(amount);
 
         if (Objects.requireNonNull(approveResponseDTO).getPayment_method_type().equals("CARD")) {
-            CardInfo cardInfo = createCardInfo(approveResponseDTO);
-            singlePayment.setCardInfo(cardInfo);
+            CardInfo cardInfo = CardInfo.builder().approveResponseDTO(approveResponseDTO).build();
+            singlePayment.addCardInfo(cardInfo);
         }
 
         saveOrderDetails(orderType, addressId, approveResponseDTO, optionName, memberId);
@@ -211,22 +211,6 @@ public class SinglePaymentService {
         } else if (status.equals(PaymentStatus.SUCCESS.name())) {
             kakaoPaymentRedisRepository.removePaymentStatus(key);
         }
-    }
-
-    private CardInfo createCardInfo(ApproveResponseDTO approveResponseDTO) {
-        CardInfo cardInfo = new CardInfo();
-        cardInfo.setApprovedId(approveResponseDTO.getCard_info().getApproved_id());
-        cardInfo.setBin(approveResponseDTO.getCard_info().getBin());
-        cardInfo.setCardMid(approveResponseDTO.getCard_info().getCard_mid());
-        cardInfo.setCardType(approveResponseDTO.getCard_info().getCard_type());
-        cardInfo.setInstallMonth(approveResponseDTO.getCard_info().getInstall_month());
-        cardInfo.setCardItemCode(approveResponseDTO.getCard_info().getCard_item_code());
-        cardInfo.setInterestFreeInstall(approveResponseDTO.getCard_info().getInterest_free_install());
-        cardInfo.setKakaopayPurchaseCorp(approveResponseDTO.getCard_info().getKakaopay_purchase_corp());
-        cardInfo.setKakaopayPurchaseCorpCode(approveResponseDTO.getCard_info().getKakaopay_purchase_corp_code());
-        cardInfo.setKakaopayIssuerCorp(approveResponseDTO.getCard_info().getKakaopay_issuer_corp());
-        cardInfo.setKakaopayIssuerCorpCode(approveResponseDTO.getCard_info().getKakaopay_issuer_corp_code());
-        return cardInfo;
     }
 
     private Map<String,String> getKakaoPayReadyRedisFields(

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -213,6 +213,17 @@ public class SinglePaymentService {
         }
     }
 
+    /**
+     * 카카오페이 결제 준비 단계에서 Redis에 저장할 필드를 생성
+     *
+     * @param partnerOrderId 파트너사 주문 ID
+     * @param orderType 주문 타입
+     * @param tid 카카오페이 트랜잭션 ID
+     * @param paymentRequestDTO 결제 요청 정보를 담고 있는 객체 (BasePaymentRequestDTO 타입)
+     *
+     * @return Redis에 저장할 필드 값들을 키-값 쌍으로 담고 있는 Map 객체
+     */
+
     private Map<String,String> getKakaoPayReadyRedisFields(
             final String partnerOrderId,
             final String orderType,

--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -127,7 +127,7 @@ public class SinglePaymentService {
         product.decreaseQuantity(quantity);
         product.increasePurchaseParticipantCount(quantity);
 
-        SinglePayment singlePayment = createSinglePayment(approveResponseDTO);
+        SinglePayment singlePayment = SinglePayment.builder().approveResponseDTO(approveResponseDTO).build();
         Amount amount = createAmount(approveResponseDTO);
         singlePayment.setAmount(amount);
 
@@ -184,23 +184,6 @@ public class SinglePaymentService {
         return now.format(formatter);
     }
 
-    private SinglePayment createSinglePayment(ApproveResponseDTO approveResponseDTO) {
-        SinglePayment singlePayment = new SinglePayment();
-        singlePayment.setAid(Objects.requireNonNull(approveResponseDTO).getAid());
-        singlePayment.setTid(approveResponseDTO.getTid());
-        singlePayment.setCid(approveResponseDTO.getCid());
-        singlePayment.setSid(approveResponseDTO.getSid());
-        singlePayment.setPartnerOrderId(approveResponseDTO.getPartner_order_id());
-        singlePayment.setPartnerUserId(approveResponseDTO.getPartner_user_id());
-        singlePayment.setPaymentMethodType(approveResponseDTO.getPayment_method_type());
-        singlePayment.setItemName(approveResponseDTO.getItem_name());
-        singlePayment.setItemCode(approveResponseDTO.getItem_code());
-        singlePayment.setQuantity(approveResponseDTO.getQuantity());
-        singlePayment.setCreatedAt(approveResponseDTO.getCreated_at());
-        singlePayment.setApprovedAt(approveResponseDTO.getApproved_at());
-        singlePayment.setPayload(approveResponseDTO.getPayload());
-        return singlePayment;
-    }
 
     public String checkPaymentStatus(Long memberId) {
         String status = kakaoPaymentRedisRepository.getPaymentStatus(memberId);

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/Amount.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/Amount.java
@@ -1,10 +1,14 @@
 package com.codenear.butterfly.kakaoPay.domain;
 
+import com.codenear.butterfly.kakaoPay.domain.dto.kakao.ApproveResponseDTO;
 import jakarta.persistence.*;
-import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 @Entity
-@Setter
+@NoArgsConstructor
 public class Amount {
 
     @Id
@@ -18,4 +22,13 @@ public class Amount {
 
     @OneToOne(mappedBy = "amount")
     private SinglePayment singlePayment;
+
+    @Builder
+    public Amount (ApproveResponseDTO approveResponseDTO) {
+        this.total = Objects.requireNonNull(approveResponseDTO).getAmount().getTotal();
+        this.taxFree = approveResponseDTO.getAmount().getTax_free();
+        this.vat = approveResponseDTO.getAmount().getVat();
+        this.point = approveResponseDTO.getAmount().getPoint();
+        this.discount = approveResponseDTO.getAmount().getDiscount();
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/CancelPayment.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/CancelPayment.java
@@ -1,11 +1,11 @@
 package com.codenear.butterfly.kakaoPay.domain;
 
+import com.codenear.butterfly.kakaoPay.domain.dto.kakao.CancelResponseDTO;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
-@Setter
 @NoArgsConstructor
 public class CancelPayment {
 
@@ -30,4 +30,25 @@ public class CancelPayment {
     private String createdAt; // 결제 준비 요청 시간
     private String approvedAt; // 결제 승인 시간
     private String payload; // 결제 승인 요청에 대해 저장 값, 요청 시 전달된 내용
+
+    @Builder
+    public CancelPayment(CancelResponseDTO cancelResponseDTO) {
+        this.aid = cancelResponseDTO.getAid();
+        this.tid = cancelResponseDTO.getTid();
+        this.cid = cancelResponseDTO.getCid();
+        this.status = cancelResponseDTO.getStatus();
+        this.partnerOrderId = cancelResponseDTO.getPartner_order_id();
+        this.partnerUserId = cancelResponseDTO.getPartner_user_id();
+        this.paymentMethodType = cancelResponseDTO.getPayment_method_type();
+        this.itemName = cancelResponseDTO.getItem_name();
+        this.itemCode = cancelResponseDTO.getItem_code();
+        this.quantity = cancelResponseDTO.getQuantity();
+        this.createdAt = cancelResponseDTO.getCreated_at();
+        this.approvedAt = cancelResponseDTO.getApproved_at();
+        this.payload = cancelResponseDTO.getPayload();
+    }
+
+    public void addCanceledAmount(CanceledAmount canceledAmount) {
+        this.canceledAmount = canceledAmount;
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/CanceledAmount.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/CanceledAmount.java
@@ -1,10 +1,12 @@
 package com.codenear.butterfly.kakaoPay.domain;
 
+import com.codenear.butterfly.kakaoPay.domain.dto.kakao.CancelResponseDTO;
 import jakarta.persistence.*;
-import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
-@Setter
+@NoArgsConstructor
 public class CanceledAmount {
 
     @Id
@@ -18,4 +20,13 @@ public class CanceledAmount {
 
     @OneToOne(mappedBy = "canceledAmount")
     private CancelPayment cancelPayment;
+
+    @Builder
+    public CanceledAmount(CancelResponseDTO cancelResponseDTO) {
+        this.total = cancelResponseDTO.getAmount().getTotal();
+        this.taxFree = cancelResponseDTO.getAmount().getTax_free();
+        this.vat = cancelResponseDTO.getAmount().getVat();
+        this.point = cancelResponseDTO.getAmount().getPoint();
+        this.discount = cancelResponseDTO.getAmount().getDiscount();
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/CardInfo.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/CardInfo.java
@@ -1,12 +1,14 @@
 package com.codenear.butterfly.kakaoPay.domain;
 
+import com.codenear.butterfly.kakaoPay.domain.dto.kakao.ApproveResponseDTO;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Setter
+@NoArgsConstructor
 public class CardInfo {
 
     @Id
@@ -27,4 +29,20 @@ public class CardInfo {
 
     @OneToOne(mappedBy = "cardInfo")
     private SinglePayment singlePayment;
+
+    @Builder
+    public CardInfo(ApproveResponseDTO approveResponseDTO) {
+        this.approvedId = approveResponseDTO.getCard_info().getApproved_id();
+        this.bin = approveResponseDTO.getCard_info().getBin();
+        this.cardMid = approveResponseDTO.getCard_info().getCard_mid();
+        this.cardType = approveResponseDTO.getCard_info().getCard_type();
+        this.installMonth = approveResponseDTO.getCard_info().getInstall_month();
+        this.cardItemCode = approveResponseDTO.getCard_info().getCard_item_code();
+        this.installmentType = approveResponseDTO.getCard_info().getInstallment_type();
+        this.interestFreeInstall = approveResponseDTO.getCard_info().getInterest_free_install();
+        this.kakaopayPurchaseCorp = approveResponseDTO.getCard_info().getKakaopay_purchase_corp();
+        this.kakaopayPurchaseCorpCode = approveResponseDTO.getCard_info().getKakaopay_purchase_corp_code();
+        this.kakaopayIssuerCorp = approveResponseDTO.getCard_info().getKakaopay_issuer_corp();
+        this.kakaopayIssuerCorpCode = approveResponseDTO.getCard_info().getKakaopay_issuer_corp_code();
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/KakaoPayRedisField.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/KakaoPayRedisField.java
@@ -1,0 +1,22 @@
+package com.codenear.butterfly.kakaoPay.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public enum KakaoPayRedisField {
+    ORDER_ID("orderId"),
+    ORDER_TYPE("orderType"),
+    TRANSACTION_ID("transactionId"),
+    ADDRESS_ID("addressId"),
+    OPTION_NAME("optionName"),
+    PAYMENT_STATUS("paymentStatus"),
+    PICKUP_PLACE("pickupPlace"),
+    PICKUP_DATE("pickupDate"),
+    PICKUP_TIME("pickupTime");
+
+    private String fieldName;
+}

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/OrderDetails.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/OrderDetails.java
@@ -1,19 +1,24 @@
 package com.codenear.butterfly.kakaoPay.domain;
 
+import com.codenear.butterfly.address.domain.Address;
 import com.codenear.butterfly.kakaoPay.domain.dto.OrderStatus;
 import com.codenear.butterfly.kakaoPay.domain.dto.OrderType;
+import com.codenear.butterfly.kakaoPay.domain.dto.kakao.ApproveResponseDTO;
 import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.product.domain.Product;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 @Entity
 @Getter
-@Setter
+@NoArgsConstructor
 public class OrderDetails {
 
     @Id
@@ -51,4 +56,41 @@ public class OrderDetails {
 
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
+
+    @Builder
+    public OrderDetails(Member member, OrderType orderType, ApproveResponseDTO approveResponseDTO, Product product, String optionName) {
+        this.member = member;
+        this.orderType = orderType;
+        this.orderCode = generateOrderCode();
+        this.createdAt = LocalDateTime.parse(approveResponseDTO.getCreated_at());
+        this.tid = approveResponseDTO.getTid();
+        this.total = approveResponseDTO.getAmount().getTotal();
+        this.productName = approveResponseDTO.getItem_name();
+        this.productImage = product.getProductImage();
+        this.optionName = optionName;
+        this.quantity = approveResponseDTO.getQuantity();
+        this.orderStatus = OrderStatus.READY;
+
+    }
+
+    public void addOrderTypeByPickup(String pickupPlace, LocalDate pickupDate, LocalTime pickupTime) {
+        this.pickupPlace = pickupPlace;
+        this.pickupDate = pickupDate;
+        this.pickupTime = pickupTime;
+    }
+
+    public void addOrderTypeByDeliver(Address address) {
+        this.address = address.getAddress();
+        this.detailedAddress = address.getDetailedAddress();
+    }
+
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+    }
+
+    private String generateOrderCode() {
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMddHHmmssSSSS");
+        return now.format(formatter);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/PaymentMethod.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/PaymentMethod.java
@@ -3,6 +3,8 @@ package com.codenear.butterfly.kakaoPay.domain;
 import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.kakaoPay.exception.KakaoPayException;
 
+import java.util.Arrays;
+
 public enum PaymentMethod {
     CARD,
     MONEY;
@@ -15,11 +17,9 @@ public enum PaymentMethod {
      * @throws IllegalArgumentException 매핑되는 Enum 값이 없을 경우 예외 발생
      */
     public static PaymentMethod fromString(String name) {
-        for (PaymentMethod type : PaymentMethod.values()) {
-            if (type.name().equalsIgnoreCase(name)) { // 대소문자 구분 없이 비교
-                return type;
-            }
-        }
-        throw new KakaoPayException(ErrorCode.INVALID_PAYMENT_METHOD, "결제 방식을 확인해주세요" + name);
+        return Arrays.stream(PaymentMethod.values())
+                .filter(value -> value.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new KakaoPayException(ErrorCode.INVALID_PAYMENT_METHOD, String.format("결제 방식을 확인해주세요: %s",name)));
     }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/PaymentMethod.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/PaymentMethod.java
@@ -1,0 +1,25 @@
+package com.codenear.butterfly.kakaoPay.domain;
+
+import com.codenear.butterfly.global.exception.ErrorCode;
+import com.codenear.butterfly.kakaoPay.exception.KakaoPayException;
+
+public enum PaymentMethod {
+    CARD,
+    MONEY;
+
+    /**
+     * String 값을 기반으로 Enum 값을 반환하는 메서드
+     *
+     * @param name 문자열 값
+     * @return 해당 문자열에 매핑되는 Enum 값
+     * @throws IllegalArgumentException 매핑되는 Enum 값이 없을 경우 예외 발생
+     */
+    public static PaymentMethod fromString(String name) {
+        for (PaymentMethod type : PaymentMethod.values()) {
+            if (type.name().equalsIgnoreCase(name)) { // 대소문자 구분 없이 비교
+                return type;
+            }
+        }
+        throw new KakaoPayException(ErrorCode.INVALID_PAYMENT_METHOD, "결제 방식을 확인해주세요" + name);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
@@ -19,7 +19,9 @@ public class SinglePayment {
     private String sid; // 정기 결제용 ID
     private String partnerOrderId; // 가맹점 주문번호
     private String partnerUserId; // 가맹점 회원 id
-    private String paymentMethodType; // 결제 수단(CARD 또는 MONEY)
+
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethodType; // 결제 수단(CARD 또는 MONEY)
 
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "amount_id")
@@ -44,7 +46,7 @@ public class SinglePayment {
         this.sid = approveResponseDTO.getSid();
         this.partnerOrderId = approveResponseDTO.getPartner_order_id();
         this.partnerUserId = approveResponseDTO.getPartner_user_id();
-        this.paymentMethodType = approveResponseDTO.getPayment_method_type();
+        this.paymentMethodType = PaymentMethod.fromString(approveResponseDTO.getPayment_method_type());
         this.itemName = approveResponseDTO.getItem_name();
         this.itemCode = approveResponseDTO.getItem_code();
         this.quantity = approveResponseDTO.getQuantity();

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
@@ -52,4 +52,8 @@ public class SinglePayment {
         this.approvedAt = approveResponseDTO.getApproved_at();
         this.payload = approveResponseDTO.getPayload();
     }
+
+    public void addAmount(Amount amount) {
+        this.amount = amount;
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
@@ -1,11 +1,13 @@
 package com.codenear.butterfly.kakaoPay.domain;
 
+import com.codenear.butterfly.kakaoPay.domain.dto.kakao.ApproveResponseDTO;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import java.util.Objects;
 
 @Entity
-@Setter
 @NoArgsConstructor
 public class SinglePayment {
     @Id
@@ -34,4 +36,20 @@ public class SinglePayment {
     private String approvedAt; // 결제 승인 시간
     private String payload; // 결제 승인 요청에 대해 저장 값, 요청 시 전달된 내용
 
+    @Builder
+    public SinglePayment (ApproveResponseDTO approveResponseDTO) {
+        this.aid = Objects.requireNonNull(approveResponseDTO).getAid();
+        this.tid = approveResponseDTO.getTid();
+        this.cid = approveResponseDTO.getCid();
+        this.sid = approveResponseDTO.getSid();
+        this.partnerOrderId = approveResponseDTO.getPartner_order_id();
+        this.partnerUserId = approveResponseDTO.getPartner_user_id();
+        this.paymentMethodType = approveResponseDTO.getPayment_method_type();
+        this.itemName = approveResponseDTO.getItem_name();
+        this.itemCode = approveResponseDTO.getItem_code();
+        this.quantity = approveResponseDTO.getQuantity();
+        this.createdAt = approveResponseDTO.getCreated_at();
+        this.approvedAt = approveResponseDTO.getApproved_at();
+        this.payload = approveResponseDTO.getPayload();
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/SinglePayment.java
@@ -56,4 +56,8 @@ public class SinglePayment {
     public void addAmount(Amount amount) {
         this.amount = amount;
     }
+
+    public void addCardInfo(CardInfo cardInfo) {
+        this.cardInfo = cardInfo;
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/request/PickupPaymentRequestDTO.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/request/PickupPaymentRequestDTO.java
@@ -1,5 +1,6 @@
 package com.codenear.butterfly.kakaoPay.domain.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -14,8 +15,10 @@ public class PickupPaymentRequestDTO extends BasePaymentRequestDTO {
     private String pickupPlace;
 
     @Schema(description = "픽업 날짜", example = "2024-10-21")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDate pickupDate;
 
     @Schema(description = "픽업 시간", example = "14:30")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
     private LocalTime pickupTime;
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
@@ -21,19 +21,19 @@ public class KakaoPaymentRedisRepository {
      * Redis Hash에 여러개의 데이터를 한번에 저장
      *
      * @param memberId 멤버 아이디
-     * @param fields 여러개의 필드와 값이 저장된 맵
+     * @param fields   여러개의 필드와 값이 저장된 맵
      */
     public void addMultipleToHashSet(final Long memberId, final Map<String, String> fields) {
         // 여러 값을 한 번에 저장
         redisTemplate.opsForHash().putAll(PAYMENT_HASH_KEY_PREFIX + memberId, fields);
-        ensureTTL();
+        ensureTTL(memberId);
     }
 
     /**
      * Redis Hash에서 특정 필드의 값을 가져오는 메서드
      *
      * @param memberId 멤버 아이디
-     * @param field 필드 이름
+     * @param field    필드 이름
      * @return 필드 값
      */
     public String getHashFieldValue(final Long memberId, final String field) {
@@ -52,11 +52,12 @@ public class KakaoPaymentRedisRepository {
     /**
      * TTL 시간 설정
      */
-    private void ensureTTL() {
+    private void ensureTTL(final Long memberId) {
+        String key = PAYMENT_HASH_KEY_PREFIX + memberId;
         // Hash Key가 처음 생성된 경우에만 TTL 설정
-        if (Boolean.FALSE.equals(redisTemplate.hasKey(PAYMENT_HASH_KEY_PREFIX))) {
+        if (Boolean.FALSE.equals(redisTemplate.hasKey(key + memberId))) {
             // TTL 15분 설정 (kakao pay API가 호출 후 생성되는 tid의 유효기간은 15분 이기에 15분으로 설정)
-            redisTemplate.expire(PAYMENT_HASH_KEY_PREFIX, TIME_TO_LIVE_MINUTE, TimeUnit.MILLISECONDS);
+            redisTemplate.expire(key, TIME_TO_LIVE_MINUTE, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
@@ -3,183 +3,65 @@ package com.codenear.butterfly.kakaoPay.domain.repository;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.BasePaymentRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.DeliveryPaymentRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.PickupPaymentRequestDTO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Repository
+@RequiredArgsConstructor
 public class KakaoPaymentRedisRepository {
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
-    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-
+    private static final String PAYMENT_HASH_KEY_PREFIX = "pay:";
+    private static final int TIME_TO_LIVE_MINUTE = 15;
     private final RedisTemplate<String, String> redisTemplate;
 
-    public KakaoPaymentRedisRepository(RedisTemplate<String, String> redisTemplate) {
-        this.redisTemplate = redisTemplate;
+    /**
+     * Redis Hash에 여러개의 데이터를 한번에 저장
+     *
+     * @param memberId 멤버 아이디
+     * @param fields 여러개의 필드와 값이 저장된 맵
+     */
+    public void addMultipleToHashSet(final Long memberId, final Map<String, String> fields) {
+        // 여러 값을 한 번에 저장
+        redisTemplate.opsForHash().putAll(PAYMENT_HASH_KEY_PREFIX + memberId, fields);
+        ensureTTL();
     }
 
-    public void saveOrderId(Long memberId, String orderId) {
-        String key = "order:" + memberId;
-        redisTemplate.opsForValue().set(key, orderId, 30, TimeUnit.MINUTES);
+    /**
+     * Redis Hash에서 특정 필드의 값을 가져오는 메서드
+     *
+     * @param memberId 멤버 아이디
+     * @param field 필드 이름
+     * @return 필드 값
+     */
+    public String getHashFieldValue(final Long memberId, final String field) {
+        return (String) redisTemplate.opsForHash().get(PAYMENT_HASH_KEY_PREFIX + memberId, field);
     }
 
-    public String getOrderId(Long memberId) {
-        String key = "order:" + memberId;
-        return redisTemplate.opsForValue().get(key);
+    /**
+     * 멤버의 Redis Hash Table 제거
+     *
+     * @param memberId 멤버 아이디
+     */
+    public void removeHashTableKey(final Long memberId) {
+        redisTemplate.delete(PAYMENT_HASH_KEY_PREFIX + memberId);
     }
 
-    public void removeOrderId(Long memberId) {
-        String key = "order:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    public void saveTransactionId(Long memberId, String tid) {
-        String key = "transaction:" + memberId;
-        redisTemplate.opsForValue().set(key, tid, 30, TimeUnit.MINUTES);
-    }
-
-    public String getTransactionId(Long memberId) {
-        String key = "transaction:" + memberId;
-        return redisTemplate.opsForValue().get(key);
-    }
-
-    public void removeTransactionId(Long memberId) {
-        String key = "transaction:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    public void saveOrderRelatedData(Long memberId, String orderType, BasePaymentRequestDTO paymentRequestDTO) {
-        saveOrderType(memberId, orderType);
-        saveAddressId(memberId, paymentRequestDTO);
-        saveOptionName(memberId, paymentRequestDTO);
-
-        if (paymentRequestDTO instanceof PickupPaymentRequestDTO pickupDTO) {
-            savePickupPlace(memberId, pickupDTO.getPickupPlace());
-            savePickupDate(memberId, pickupDTO.getPickupDate());
-            savePickupTime(memberId, pickupDTO.getPickupTime());
+    /**
+     * TTL 시간 설정
+     */
+    private void ensureTTL() {
+        // Hash Key가 처음 생성된 경우에만 TTL 설정
+        if (Boolean.FALSE.equals(redisTemplate.hasKey(PAYMENT_HASH_KEY_PREFIX))) {
+            // TTL 15분 설정 (kakao pay API가 호출 후 생성되는 tid의 유효기간은 15분 이기에 15분으로 설정)
+            redisTemplate.expire(PAYMENT_HASH_KEY_PREFIX, TIME_TO_LIVE_MINUTE, TimeUnit.MILLISECONDS);
         }
-    }
-
-    private void saveOrderType(Long memberId, String orderType) {
-        String key = "orderType:" + memberId;
-        redisTemplate.opsForValue().set(key, orderType, 30, TimeUnit.MINUTES);
-    }
-
-    public String getOrderType(Long memberId) {
-        String key = "orderType:" + memberId;
-        return redisTemplate.opsForValue().get(key);
-    }
-
-    private void removeOrderType(Long memberId) {
-        String key = "orderType:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    private void saveAddressId(Long memberId, BasePaymentRequestDTO paymentRequestDTO) {
-        if (paymentRequestDTO instanceof DeliveryPaymentRequestDTO) {
-            String key = "addressId:" + memberId;
-            redisTemplate.opsForValue().set(key, ((DeliveryPaymentRequestDTO) paymentRequestDTO).getAddressId().toString(), 30, TimeUnit.MINUTES);
-        }
-    }
-
-    public Long getAddressId(Long memberId) {
-        String key = "addressId:" + memberId;
-        String addressIdStr = redisTemplate.opsForValue().get(key);
-        return addressIdStr != null ? Long.parseLong(addressIdStr) : null;
-    }
-
-    private void removeAddressId(Long memberId) {
-        String key = "addressId:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    private void saveOptionName(Long memberId, BasePaymentRequestDTO paymentRequestDTO) {
-        String optionName = paymentRequestDTO.getOptionName();
-        if (optionName != null) {
-            String key = "optionName:" + memberId;
-            redisTemplate.opsForValue().set(key, optionName, 30, TimeUnit.MINUTES);
-        }
-    }
-
-    public String getOptionName(Long memberId) {
-        String key = "optionName:" + memberId;
-        return redisTemplate.opsForValue().get(key);
-    }
-
-    private void removeOptionName(Long memberId) {
-        String key = "optionName:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    private void savePickupDate(Long memberId, LocalDate pickupDate) {
-        if (pickupDate != null) {
-            String key = "pickupDate:" + memberId;
-            String dateStr = pickupDate.format(DATE_FORMATTER);
-            redisTemplate.opsForValue().set(key, dateStr, 30, TimeUnit.MINUTES);
-        }
-    }
-
-    public LocalDate getPickupDate(Long memberId) {
-        String key = "pickupDate:" + memberId;
-        String dateStr = redisTemplate.opsForValue().get(key);
-        return dateStr != null ? LocalDate.parse(dateStr, DATE_FORMATTER) : null;
-    }
-
-    private void removePickupDate(Long memberId) {
-        String key = "pickupDate:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    private void savePickupTime(Long memberId, LocalTime pickupTime) {
-        if (pickupTime != null) {
-            String key = "pickupTime:" + memberId;
-            String timeStr = pickupTime.format(TIME_FORMATTER);
-            redisTemplate.opsForValue().set(key, timeStr, 30, TimeUnit.MINUTES);
-        }
-    }
-
-    public LocalTime getPickupTime(Long memberId) {
-        String key = "pickupTime:" + memberId;
-        String timeStr = redisTemplate.opsForValue().get(key);
-        return timeStr != null ? LocalTime.parse(timeStr, TIME_FORMATTER) : null;
-    }
-
-    private void removePickupTime(Long memberId) {
-        String key = "pickupTime:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    private void savePickupPlace(Long memberId, String pickupPlace) {
-        if (pickupPlace != null) {
-            String key = "pickupPlace:" + memberId;
-            redisTemplate.opsForValue().set(key, pickupPlace, 30, TimeUnit.MINUTES);
-        }
-    }
-
-    public String getPickupPlace(Long memberId) {
-        String key = "pickupPlace:" + memberId;
-        return redisTemplate.opsForValue().get(key);
-    }
-
-    private void removePickupPlace(Long memberId) {
-        String key = "pickupPlace:" + memberId;
-        redisTemplate.delete(key);
-    }
-
-    public void removeOrderRelatedData(Long memberId) {
-        removeOrderId(memberId);
-        removeTransactionId(memberId);
-        removeOrderType(memberId);
-        removeAddressId(memberId);
-        removeOptionName(memberId);
-        removePickupDate(memberId);
-        removePickupTime(memberId);
-        removePickupPlace(memberId);
     }
 
     public void savePaymentStatus(Long memberId, String status) {

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
@@ -1,17 +1,13 @@
 package com.codenear.butterfly.kakaoPay.domain.repository;
 
-import com.codenear.butterfly.kakaoPay.domain.dto.request.BasePaymentRequestDTO;
-import com.codenear.butterfly.kakaoPay.domain.dto.request.DeliveryPaymentRequestDTO;
-import com.codenear.butterfly.kakaoPay.domain.dto.request.PickupPaymentRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static com.codenear.butterfly.kakaoPay.domain.KakaoPayRedisField.PAYMENT_STATUS;
 
 @Repository
 @RequiredArgsConstructor
@@ -65,12 +61,12 @@ public class KakaoPaymentRedisRepository {
     }
 
     public void savePaymentStatus(Long memberId, String status) {
-        String key = "paymentStatus:" + memberId;
+        String key = PAYMENT_STATUS.getFieldName() + memberId;
         redisTemplate.opsForValue().set(key, status, 30, TimeUnit.MINUTES);
     }
 
     public String getPaymentStatus(Long memberId) {
-        String key = "paymentStatus:" + memberId;
+        String key = PAYMENT_STATUS.getFieldName() + memberId;
         return redisTemplate.opsForValue().get(key);
     }
 

--- a/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
@@ -1,0 +1,79 @@
+package com.codenear.butterfly.kakaoPay.util;
+
+import com.codenear.butterfly.kakaoPay.domain.OrderDetails;
+import com.codenear.butterfly.kakaoPay.domain.dto.request.BasePaymentRequestDTO;
+import com.codenear.butterfly.kakaoPay.domain.dto.request.CancelRequestDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class KakaoPaymentUtil<T> {
+    @Value("${kakao.payment.cid}")
+    private String CID;
+
+    @Value("${kakao.payment.secret-key-dev}")
+    private String secretKey;
+
+    @Value("${kakao.payment.host}")
+    private String host;
+
+    @Value("${kakao.payment.request-url}")
+    private String requestUrl;
+
+    public <T> T sendRequest(String requestType, Map<String, Object> parameters, Class<T> responseType) {
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(parameters, getHeaders());
+        return new RestTemplate().postForObject(
+                host + requestType,
+                requestEntity,
+                responseType);
+    }
+
+    public Map<String, Object> getKakaoPayReadyParameters(BasePaymentRequestDTO paymentRequestDTO, Long memberId, String partnerOrderId) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("cid", CID);
+        parameters.put("partner_order_id", partnerOrderId);
+        parameters.put("partner_user_id", memberId.toString());
+        parameters.put("item_name", paymentRequestDTO.getProductName());
+        parameters.put("quantity", paymentRequestDTO.getQuantity());
+        parameters.put("total_amount", paymentRequestDTO.getTotal());
+        parameters.put("vat_amount", 0);
+        parameters.put("tax_free_amount", 0);
+        parameters.put("approval_url", requestUrl + "/payment/success?memberId=" + memberId);
+        parameters.put("cancel_url", requestUrl + "/payment/cancel?memberId=" + memberId);
+        parameters.put("fail_url", requestUrl + "/payment/fail?memberId=" + memberId);
+        parameters.put("return_custom_url", "butterfly://");
+        return parameters;
+    }
+
+    public Map<String, Object> getKakaoPayApproveParameters(Long memberId, String orderId, String transactionId, String pgToken) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("cid", CID);
+        parameters.put("tid", transactionId);
+        parameters.put("partner_order_id", orderId);
+        parameters.put("partner_user_id", memberId.toString());
+        parameters.put("pg_token", pgToken);
+        return parameters;
+    }
+
+    public Map<String,Object> getKakaoPayCancelParameters(OrderDetails orderDetails, CancelRequestDTO cancelRequestDTO) {
+        Map<String,Object> parameters = new HashMap<>();
+        parameters.put("cid", CID);
+        parameters.put("tid", orderDetails.getTid());
+        parameters.put("cancel_amount", cancelRequestDTO.getCancelAmount());
+        parameters.put("cancel_tax_free_amount", 0);
+
+        return parameters;
+    }
+    private HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        headers.set("Authorization", "SECRET_KEY " + secretKey);
+        return headers;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#399 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- Redis 저장 구조를 Table -> Hash로 변경
- HashMap put 메서드를 사용할 때 value의 값이 null이라면 저장하지 않도록 Overriding
- 객체 생성 방식을 Setter 방식에서 생성자 Builder 방식으로 변경
- 매직넘버 값들을 enum으로 변경
- KakaoPay API 요청 및 Parameter 생성 메서드를 KakaoPaymentUtil로 분리하여 중복 코드 제거

## 🔧 앞으로의 과제 **(Optional)**

- 카카오페이 테스트 결제 -> 실결제 로 변경
