### PR TITLE
fix(S3Directory): S3 저장 디렉토리 변경 (#402)

### DIFF
--- a/src/main/java/com/codenear/butterfly/s3/domain/S3Directory.java
+++ b/src/main/java/com/codenear/butterfly/s3/domain/S3Directory.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 @Getter
 public enum S3Directory {
     TEST("test/"),
-    PROFILE_IMAGE("image/"),
-    PRODUCT_IMAGE("/");
+    PROFILE_IMAGE("profile/image"),
+    PRODUCT_IMAGE("product/image");
 
     private final String value;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #402

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- PRODUCT_IMAGE("/") 기본 경로에서 -> "product/image"로 변경해 오류 해결했습니다.

- 추후 파일 관리를 용이하게 하기 위해 profileImage 디렉토리도 추가 개선했습니다.
