### PR TITLE
404 feat 전체 알림 미확인 알림 개수 기능

### DIFF
--- a/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
@@ -102,7 +102,7 @@ public class AdminProductService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void sendNewProductNotification() {
         fcmFacade.sendTopicMessage(NEW_PRODUCT, MARKETING.getTopic());
     }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
@@ -57,7 +57,7 @@ public class KakaoPaymentRedisRepository {
         // Hash Key가 처음 생성된 경우에만 TTL 설정
         if (Boolean.FALSE.equals(redisTemplate.hasKey(key + memberId))) {
             // TTL 15분 설정 (kakao pay API가 호출 후 생성되는 tid의 유효기간은 15분 이기에 15분으로 설정)
-            redisTemplate.expire(key, TIME_TO_LIVE_MINUTE, TimeUnit.MILLISECONDS);
+            redisTemplate.expire(key, TIME_TO_LIVE_MINUTE, TimeUnit.MINUTES);
         }
     }
 

--- a/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
@@ -32,7 +32,10 @@ public class AlarmService {
     }
 
     public void addSingleAlarm(NotifyMessage message, Member member) {
-        Alarm alarm = Alarm.builder().notifyMessage(message).member(member).build();
+        Alarm alarm = Alarm.builder()
+                .notifyMessage(message)
+                .member(member)
+                .build();
         alarmRepository.save(alarm);
     }
 

--- a/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
@@ -47,7 +47,6 @@ public class AlarmService {
      * @param memberId 멤버 아이디
      * @return 미확인 알림 개수 반환 ResponseDTO
      */
-    @Transactional(readOnly = true)
     public AlarmCountResponseDTO getAlarmCountByMember(Long memberId) {
         Long unreadCount = alarmRedisRepository.getTotalUnreadAlarms(memberId);
         return AlarmCountResponseDTO.builder()

--- a/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
@@ -24,14 +24,6 @@ public class AlarmService {
     private final AlarmRedisRepository alarmRedisRepository;
     private final ConsentDataAccess consentDataAccess;
 
-    private static Alarm createAlarm(final NotifyMessage message, final Member member) {
-        return Alarm.builder()
-                .notifyMessage(message)
-                .member(member)
-                .isNew(true)
-                .build();
-    }
-
     public AlarmsResponse getAlarmsByMemberId(Long memberId) {
         List<Alarm> alarms = alarmRepository.findByMemberId(memberId);
         alarmRepository.markAllAsReadByMemberId(memberId); // 전체 읽음 처리
@@ -40,7 +32,8 @@ public class AlarmService {
     }
 
     public void addSingleAlarm(NotifyMessage message, Member member) {
-        alarmRepository.save(createAlarm(message, member));
+        Alarm alarm = Alarm.builder().notifyMessage(message).member(member).build();
+        alarmRepository.save(alarm);
     }
 
     public void addConsentBasedAlarms(NotifyMessage message) {

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/Alarm.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/Alarm.java
@@ -37,4 +37,11 @@ public class Alarm extends BaseEntity {
     private Member member;
 
     private boolean isNew;
+
+    @Builder
+    public Alarm(final NotifyMessage message, final Member member) {
+        this.notifyMessage = message;
+        this.member = member;
+        this.isNew = true;
+    }
 }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/dto/AlarmCountResponseDTO.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/dto/AlarmCountResponseDTO.java
@@ -1,0 +1,10 @@
+package com.codenear.butterfly.notify.alarm.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(title = "미확인 알림 JSON", description = "사용자 미확인 알림 개수 요청 시 반환하는 JSON")
+public record AlarmCountResponseDTO(
+        @Schema(description = "미확인 알림 개수") Long unreadAlarmCount) {
+}

--- a/src/main/java/com/codenear/butterfly/notify/alarm/infrastructure/AlarmRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/infrastructure/AlarmRedisRepository.java
@@ -1,0 +1,106 @@
+package com.codenear.butterfly.notify.alarm.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AlarmRedisRepository {
+    private final String ALARM_REDIS_PREFIX = "unread_alarm:";
+    private final String BROADCAST_COUNT_KEY = "broadcast_count";
+    private final String LAST_READ_BROADCAST_PREFIX = "last_read_broadcast:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 알림이 생성되었을 때 미확인 알림 개수 증가
+     *
+     * @param memberId 멤버 아이디
+     */
+    public void incrementAlarmByMember(Long memberId) {
+        redisTemplate.opsForValue().increment(ALARM_REDIS_PREFIX + memberId);
+    }
+
+    /**
+     * 알림을 확인했다면 지금까지 읽지 않은 알림은 모두 읽음 처리
+     *
+     * @param memberId 멤버 아이디
+     */
+    public void readAlarm(Long memberId) {
+        redisTemplate.delete(ALARM_REDIS_PREFIX + memberId);
+        setLastReadBroadcast(memberId);
+    }
+
+    /**
+     * 전역 브로드캐스트 발행 개수 증가
+     */
+    public void incrementBroadcastVersion() {
+        redisTemplate.opsForValue().increment(BROADCAST_COUNT_KEY);
+    }
+
+    /**
+     * 총 미확인 알림 개수 계산 (개별 + 브로드캐스트)
+     *
+     * @param memberId 사용자 ID
+     * @return 총 미확인 알림 개수
+     */
+    public Long getTotalUnreadAlarms(Long memberId) {
+        String memberUnreadCount = getAlarmCount(memberId);
+        Long userUnread = memberUnreadCount != null ? Long.parseLong(memberUnreadCount) : 0L;
+        Long broadcastUnread = getUnreadBroadcastCount(memberId);
+        return userUnread + broadcastUnread;
+    }
+
+    /**
+     * 전체 브로드캐스트 메시지의 미확인 개수 계산
+     *
+     * @param memberId 사용자 ID
+     * @return 미확인 브로드캐스트 메시지 개수
+     */
+    private Long getUnreadBroadcastCount(Long memberId) {
+        Long currentBroadcastCount = getCurrentBroadcastVersion();
+        Long memberLastReadNumber = getLastReadBroadcast(memberId);
+        return currentBroadcastCount - memberLastReadNumber;
+    }
+
+    /**
+     * 사용자별 마지막 읽은 브로드캐스트 버전 조회
+     *
+     * @param memberId 사용자 ID
+     * @return 마지막 읽은 브로드캐스트 버전
+     */
+    private Long getLastReadBroadcast(Long memberId) {
+        String lastReadBroadcastNumber = redisTemplate.opsForValue().get(LAST_READ_BROADCAST_PREFIX + memberId);
+        return lastReadBroadcastNumber != null ? Long.parseLong(lastReadBroadcastNumber) : 0L;
+    }
+
+    /**
+     * 전역 알림을 제외한 알림개수
+     *
+     * @param memberId 멤버 아이디
+     * @return 사용자 미확인 알림 개수
+     */
+    private String getAlarmCount(Long memberId) {
+        return redisTemplate.opsForValue().get(ALARM_REDIS_PREFIX + memberId);
+    }
+
+    /**
+     * 현재 브로드캐스트 발행 개수 조회
+     *
+     * @return 현재 브로드캐스트 버전
+     */
+    private Long getCurrentBroadcastVersion() {
+        String broadcastCount = redisTemplate.opsForValue().get(BROADCAST_COUNT_KEY);
+        return broadcastCount != null ? Long.parseLong(broadcastCount) : 0L;
+    }
+
+    /**
+     * 사용자별 마지막 읽은 브로드캐스트 버전 설정
+     *
+     * @param memberId 사용자 ID
+     */
+    private void setLastReadBroadcast(Long memberId) {
+        redisTemplate.opsForValue().set(LAST_READ_BROADCAST_PREFIX + memberId, getCurrentBroadcastVersion().toString());
+    }
+}

--- a/src/main/java/com/codenear/butterfly/notify/alarm/presentation/AlarmController.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/presentation/AlarmController.java
@@ -27,7 +27,7 @@ public class AlarmController implements AlarmControllerSwagger {
     }
 
     @GetMapping("/count")
-    public ResponseEntity<ResponseDTO> getUnreadAlarmCount(MemberDTO loginMember) {
+    public ResponseEntity<ResponseDTO> getUnreadAlarmCount(@AuthenticationPrincipal MemberDTO loginMember) {
         AlarmCountResponseDTO unreadAlarmCount = alarmService.getAlarmCountByMember(loginMember.getId());
         return ResponseUtil.createSuccessResponse(unreadAlarmCount);
     }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/presentation/AlarmController.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/presentation/AlarmController.java
@@ -4,6 +4,7 @@ import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import com.codenear.butterfly.notify.alarm.application.AlarmService;
+import com.codenear.butterfly.notify.alarm.domain.dto.AlarmCountResponseDTO;
 import com.codenear.butterfly.notify.alarm.domain.dto.AlarmsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,5 +24,11 @@ public class AlarmController implements AlarmControllerSwagger {
     public ResponseEntity<ResponseDTO> getAlarms(@AuthenticationPrincipal MemberDTO loginMember) {
         AlarmsResponse alarms = alarmService.getAlarmsByMemberId(loginMember.getId());
         return ResponseUtil.createSuccessResponse(alarms);
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<ResponseDTO> getUnreadAlarmCount(MemberDTO loginMember) {
+        AlarmCountResponseDTO unreadAlarmCount = alarmService.getAlarmCountByMember(loginMember.getId());
+        return ResponseUtil.createSuccessResponse(unreadAlarmCount);
     }
 }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/presentation/AlarmControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/presentation/AlarmControllerSwagger.java
@@ -2,6 +2,7 @@ package com.codenear.butterfly.notify.alarm.presentation;
 
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.notify.alarm.domain.dto.AlarmCountResponseDTO;
 import com.codenear.butterfly.notify.alarm.domain.dto.AlarmsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,4 +23,12 @@ public interface AlarmControllerSwagger {
             @ApiResponse(responseCode = "200", description = "Success")
     })
     ResponseEntity<ResponseDTO> getAlarms(@AuthenticationPrincipal MemberDTO loginMember);
+
+    @Operation(summary = "미확인 알림 개수", description = "미확인 알림 개수 반환 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "body", description = "응답 메시지 예시",
+                    content = @Content(schema = @Schema(implementation = AlarmCountResponseDTO.class))),
+            @ApiResponse(responseCode = "200", description = "Success")
+    })
+    ResponseEntity<ResponseDTO> getUnreadAlarmCount(@AuthenticationPrincipal MemberDTO loginMember);
 }

--- a/src/main/java/com/codenear/butterfly/notify/fcm/application/FCMFacade.java
+++ b/src/main/java/com/codenear/butterfly/notify/fcm/application/FCMFacade.java
@@ -1,7 +1,8 @@
 package com.codenear.butterfly.notify.fcm.application;
 
-import com.codenear.butterfly.notify.NotifyMessage;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.notify.NotifyMessage;
+import com.codenear.butterfly.notify.alarm.infrastructure.AlarmRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,7 @@ public class FCMFacade {
 
     private final FCMTokenService fcmTokenService;
     private final FCMMessageService fcmMessageService;
+    private final AlarmRedisRepository alarmRedisRepository;
 
     public void save(String token, MemberDTO loginMember) {
         fcmTokenService.saveFCM(token, loginMember);
@@ -18,10 +20,12 @@ public class FCMFacade {
 
     public void sendMessage(NotifyMessage fcmMessageConstant, Long memberId) {
         fcmMessageService.sendNotificationMessage(fcmMessageConstant, memberId);
+        alarmRedisRepository.incrementAlarmByMember(memberId);
     }
 
     public void sendTopicMessage(NotifyMessage fcmMessageConstant, String topic) {
         fcmMessageService.sendTopic(fcmMessageConstant, topic);
+        alarmRedisRepository.incrementBroadcastVersion();
     }
 
     public void subscribeToTopic(Long memberId, String topic) {

--- a/src/test/java/com/codenear/butterfly/notify/alarm/application/AlarmServiceTest.java
+++ b/src/test/java/com/codenear/butterfly/notify/alarm/application/AlarmServiceTest.java
@@ -1,22 +1,31 @@
 package com.codenear.butterfly.notify.alarm.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.codenear.butterfly.member.domain.Member;
 import com.codenear.butterfly.notify.NotifyMessage;
 import com.codenear.butterfly.notify.alarm.domain.Alarm;
 import com.codenear.butterfly.notify.alarm.domain.dto.AlarmResponse;
 import com.codenear.butterfly.notify.alarm.domain.dto.AlarmsResponse;
+import com.codenear.butterfly.notify.alarm.infrastructure.AlarmRedisRepository;
 import com.codenear.butterfly.notify.alarm.infrastructure.AlarmRepository;
-import java.util.List;
+import com.codenear.butterfly.notify.fcm.application.FCMFacade;
+import com.codenear.butterfly.notify.fcm.application.FCMMessageService;
+import com.codenear.butterfly.notify.fcm.application.FCMTokenService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AlarmServiceTest {
@@ -24,14 +33,33 @@ class AlarmServiceTest {
     @Mock
     private AlarmRepository alarmRepository;
 
+    @Mock
+    private AlarmRedisRepository alarmRedisRepository;
+
+    @Mock
+    private FCMMessageService fcmMessageService;
+
+    @Mock
+    private FCMTokenService fcmTokenService;
+
+    @InjectMocks
+    private FCMFacade fcmFacade;
+
     @InjectMocks
     private AlarmService alarmService;
+
+    private Long memberId;
+    private NotifyMessage message;
+
+    @BeforeEach
+    void setUp() {
+        memberId = 1L;
+        message = mock(NotifyMessage.class);
+    }
 
     @Test
     void 유저_아이디로_알림_목록을_반환한다() {
         // given
-        Long memberId = 1L;
-        NotifyMessage message = mock(NotifyMessage.class);
         Member member = mock(Member.class);
 
         Alarm alarm = Alarm.builder()
@@ -55,5 +83,86 @@ class AlarmServiceTest {
                 .hasSize(alarms.size())
                 .extracting(AlarmResponse::id)
                 .containsExactly(memberId);
+    }
+
+    @Test
+    void 개인_알림을_발행하면_미확인_알림_개수가_증가한다() {
+        //given
+        AtomicLong unreadCount = new AtomicLong(0L);
+
+        doAnswer(invocation -> {
+            unreadCount.incrementAndGet();
+            return null;
+        }).when(alarmRedisRepository).incrementAlarmByMember(memberId);
+
+        when(alarmService.getAlarmCountByMember(memberId))
+                .thenAnswer(invocation -> unreadCount.get());
+
+        //when
+        fcmFacade.sendMessage(message, memberId);
+        alarmService.getAlarmCountByMember(memberId);
+
+        //then
+        verify(alarmRedisRepository, times(1)).incrementAlarmByMember(memberId);
+        verify(alarmRedisRepository, times(1)).getTotalUnreadAlarms(memberId);
+        assertThat(alarmService.getAlarmCountByMember(memberId).unreadAlarmCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void 전역_알림을_발송하면_미확인_알림_개수가_증가한다() {
+        // given
+        String topic = "topic";
+        AtomicLong unreadCount = new AtomicLong(0L);
+
+        doAnswer(invocation -> {
+            unreadCount.incrementAndGet();
+            return null;
+        }).when(alarmRedisRepository).incrementBroadcastVersion();
+
+        when(alarmService.getAlarmCountByMember(memberId))
+                .thenAnswer(invocation -> unreadCount.get());
+
+        //when
+        fcmFacade.sendTopicMessage(message, topic);
+
+        //then
+        verify(alarmRedisRepository, times(1)).incrementBroadcastVersion();
+        assertThat(alarmService.getAlarmCountByMember(memberId).unreadAlarmCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void 알림을_확인하면_미확인_알림_개수가_초기화된다() {
+        //given
+        AtomicLong unreadCount = new AtomicLong(0L);
+
+        doAnswer(invocation -> {
+            unreadCount.incrementAndGet();
+            return null;
+        }).when(alarmRedisRepository).incrementAlarmByMember(memberId);
+
+        doAnswer(invocation -> {
+            unreadCount.set(0L);
+            return null;
+        }).when(alarmRedisRepository).readAlarm(memberId);
+
+        when(alarmService.getAlarmCountByMember(memberId))
+                .thenAnswer(invocation -> unreadCount.get());
+
+        //when (알림 발송)
+        fcmFacade.sendMessage(message, memberId);
+        alarmService.getAlarmCountByMember(memberId);
+
+        //then (알림 발송)
+        verify(alarmRedisRepository, times(1)).incrementAlarmByMember(memberId);
+        verify(alarmRedisRepository, times(1)).getTotalUnreadAlarms(memberId);
+        assertThat(alarmService.getAlarmCountByMember(memberId).unreadAlarmCount()).isEqualTo(1L);
+
+        //when (알림 확인)
+        alarmService.getAlarmsByMemberId(memberId);
+
+        //then(알림 확인)
+        verify(alarmRedisRepository, times(1)).readAlarm(memberId);
+        verify(alarmRedisRepository, times(2)).getTotalUnreadAlarms(memberId);
+        assertThat(alarmService.getAlarmCountByMember(memberId).unreadAlarmCount()).isEqualTo(0L);
     }
 }

--- a/src/test/java/com/codenear/butterfly/notify/alarm/application/AlarmServiceTest.java
+++ b/src/test/java/com/codenear/butterfly/notify/alarm/application/AlarmServiceTest.java
@@ -50,11 +50,13 @@ class AlarmServiceTest {
 
     private Long memberId;
     private NotifyMessage message;
+    private AtomicLong unreadCount;
 
     @BeforeEach
     void setUp() {
         memberId = 1L;
         message = mock(NotifyMessage.class);
+        unreadCount = new AtomicLong(0L);
     }
 
     @Test
@@ -88,8 +90,6 @@ class AlarmServiceTest {
     @Test
     void 개인_알림을_발행하면_미확인_알림_개수가_증가한다() {
         //given
-        AtomicLong unreadCount = new AtomicLong(0L);
-
         doAnswer(invocation -> {
             unreadCount.incrementAndGet();
             return null;
@@ -112,7 +112,6 @@ class AlarmServiceTest {
     void 전역_알림을_발송하면_미확인_알림_개수가_증가한다() {
         // given
         String topic = "topic";
-        AtomicLong unreadCount = new AtomicLong(0L);
 
         doAnswer(invocation -> {
             unreadCount.incrementAndGet();
@@ -133,8 +132,6 @@ class AlarmServiceTest {
     @Test
     void 알림을_확인하면_미확인_알림_개수가_초기화된다() {
         //given
-        AtomicLong unreadCount = new AtomicLong(0L);
-
         doAnswer(invocation -> {
             unreadCount.incrementAndGet();
             return null;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#404 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 개인 알림 발송 시 미확인 개인 알림 개수 증가
- 전역 알림 발송 시 미확인 전역 알림 개수 증가
- 미확인 알림 개수 반환 API 개발
- 새로운 상품 추가 알림 발행 시 에러 수정

## 🔧 앞으로의 과제 **(Optional)**

- 상품 신청 게이지 전송
- 배송 정보 추가
- 카카오페이 실결제 변경
