### PR TITLE
411 fix 알림 저장 시 isnew컬럼 false오류 수정

### DIFF
--- a/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/application/AlarmService.java
@@ -33,7 +33,7 @@ public class AlarmService {
 
     public void addSingleAlarm(NotifyMessage message, Member member) {
         Alarm alarm = Alarm.builder()
-                .notifyMessage(message)
+                .message(message)
                 .member(member)
                 .build();
         alarmRepository.save(alarm);

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/Alarm.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/Alarm.java
@@ -19,7 +19,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#411 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 알림 저장 시 isNew가 항상 false로 저장되어 수정

## 🔧 앞으로의 과제 **(Optional)**

- 카카오페이 결제 리다이렉트 오류 수정
