### PR TITLE
419 fix 카카오페이 결제 오류 수정

### DIFF
--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/SinglePaymentService.java
@@ -13,6 +13,7 @@ import com.codenear.butterfly.kakaoPay.domain.dto.OrderType;
 import com.codenear.butterfly.kakaoPay.domain.dto.PaymentStatus;
 import com.codenear.butterfly.kakaoPay.domain.dto.kakao.ApproveResponseDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.kakao.ReadyResponseDTO;
+import com.codenear.butterfly.kakaoPay.domain.dto.order.OrderDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.rabbitmq.InventoryDecreaseMessageDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.BasePaymentRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.DeliveryPaymentRequestDTO;
@@ -161,6 +162,19 @@ public class SinglePaymentService {
             kakaoPaymentRedisRepository.savePaymentStatus(memberId, PaymentStatus.NONE.name());
         } else if (status.equals(PaymentStatus.SUCCESS.name())) {
             kakaoPaymentRedisRepository.removePaymentStatus(key);
+        }
+    }
+
+    /**
+     * 주문 가능 여부 확인
+     *
+     * @param orderDTO 주문한 상품명과 상품개수를 담은 DTO
+     */
+    public void isPossibleToOrder(OrderDTO orderDTO) {
+        int remainderProductQuantity = kakaoPaymentRedisRepository.getRemainderProductQuantity(orderDTO.productName());
+
+        if (remainderProductQuantity < orderDTO.orderQuantity()) {
+            throw new KakaoPayException(ErrorCode.INSUFFICIENT_STOCK, "재고가 부족합니다.");
         }
     }
 

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/order/OrderDTO.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/order/OrderDTO.java
@@ -1,0 +1,7 @@
+package com.codenear.butterfly.kakaoPay.domain.dto.order;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OrderDTO(@Schema(description = "주문 할 상품명") String productName,
+                       @Schema(description = "상품 주문 개수") int orderQuantity) {
+}

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
@@ -129,4 +129,11 @@ public class KakaoPaymentRedisRepository {
         String key = REMAINDER_PRODUCT_KEY_PREFIX + productName;
         redisTemplate.opsForValue().increment(key, quantity);
     }
+
+    public int getRemainderProductQuantity(String productName) {
+        String key = REMAINDER_PRODUCT_KEY_PREFIX + productName;
+        String remainderQuantity = redisTemplate.opsForValue().get(key);
+
+        return remainderQuantity == null ? 0 : Integer.parseInt(remainderQuantity);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayController.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayController.java
@@ -4,18 +4,20 @@ import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.kakaoPay.application.OrderDetailsService;
 import com.codenear.butterfly.kakaoPay.application.SinglePaymentService;
+import com.codenear.butterfly.kakaoPay.domain.dto.order.OrderDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.DeliveryPaymentRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.PickupPaymentRequestDTO;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
-import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/payment")
@@ -67,5 +69,11 @@ public class SinglePayController implements SinglePayControllerSwagger {
                 HttpStatus.OK,
                 "주문 내역 조회 성공",
                 orderDetailsService.getAllOrderDetails(memberDTO.getId()));
+    }
+
+    @PostMapping("/order/possible")
+    public ResponseEntity<ResponseDTO> isPossibleOrder(OrderDTO orderDTO) {
+        singlePaymentService.isPossibleToOrder(orderDTO);
+        return ResponseUtil.createSuccessResponse(null);
     }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayControllerSwagger.java
@@ -3,22 +3,22 @@ package com.codenear.butterfly.kakaoPay.presentation.singlepay;
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.OrderStatus;
 import com.codenear.butterfly.kakaoPay.domain.dto.PaymentStatus;
+import com.codenear.butterfly.kakaoPay.domain.dto.order.OrderDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.DeliveryPaymentRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.PickupPaymentRequestDTO;
+import com.codenear.butterfly.kakaoPay.exception.KakaoPayException;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.io.IOException;
 
 @Tag(name = "SinglePay", description = "**카카오페이 단건결제 API**")
 public interface SinglePayControllerSwagger {
@@ -60,4 +60,29 @@ public interface SinglePayControllerSwagger {
             @ApiResponse(responseCode = "200", description = "Success")
     })
     ResponseEntity<ResponseDTO> getAllOrderDetails(@AuthenticationPrincipal MemberDTO memberDTO);
+
+    @Operation(summary = "주문 가능 여부 확인", responses = {
+            @ApiResponse(responseCode = "200", description = "상품 주문 가능", content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ResponseDTO.class),
+                    examples = @ExampleObject(value = """
+                                {
+                                  "code": 200,
+                                  "message": "성공적으로 처리 완료 되었습니다.",
+                                  "body": null
+                                }
+                            """))),
+            @ApiResponse(responseCode = "40007", description = "재고 부족 (상품 주문 불가능)", content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = KakaoPayException.class),
+                    examples = @ExampleObject(value = """
+                                {
+                                  "code": 40007,
+                                  "message": "해당 상품의 재고가 부족합니다.",
+                                  "body": "재고가 부족합니다."
+                                }
+                            """)
+            ))
+    })
+    ResponseEntity<ResponseDTO> isPossibleOrder(@RequestBody OrderDTO orderDTO);
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
@@ -44,10 +44,10 @@ public class KakaoPaymentUtil<T> {
         parameters.put("total_amount", paymentRequestDTO.getTotal());
         parameters.put("vat_amount", 0);
         parameters.put("tax_free_amount", 0);
-        parameters.put("approval_url", requestUrl + "/payment/success?memberId=" + memberId);
-        parameters.put("cancel_url", requestUrl + "/payment/cancel?memberId=" + memberId);
-        parameters.put("fail_url", requestUrl + "/payment/fail?memberId=" + memberId);
-        parameters.put("return_custom_url", "butterfly://");
+        parameters.put("approval_url", requestUrl + "/success");
+        parameters.put("cancel_url", requestUrl + "/cancel");
+        parameters.put("fail_url", requestUrl + "/fail");
+        parameters.put("custom_json", "{\"return_custom_url\":\"butterfly://\"}");
         return parameters;
     }
 
@@ -61,8 +61,8 @@ public class KakaoPaymentUtil<T> {
         return parameters;
     }
 
-    public Map<String,Object> getKakaoPayCancelParameters(OrderDetails orderDetails, CancelRequestDTO cancelRequestDTO) {
-        Map<String,Object> parameters = new HashMap<>();
+    public Map<String, Object> getKakaoPayCancelParameters(OrderDetails orderDetails, CancelRequestDTO cancelRequestDTO) {
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("cid", CID);
         parameters.put("tid", orderDetails.getTid());
         parameters.put("cancel_amount", cancelRequestDTO.getCancelAmount());
@@ -70,6 +70,7 @@ public class KakaoPaymentUtil<T> {
 
         return parameters;
     }
+
     private HttpHeaders getHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Content-Type", "application/json");


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#419 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- approval, fail, cancel url을 백엔드 api에서 앱으로 변경
- 주문가능 여부 api 구현

## 🔧 앞으로의 과제 **(Optional)**
- 게이지 수정
- 구간 할인율 설정
- 최대 구매 개수 이상의 물품 구매 시 할인율 차액 포인트백
