### PR TITLE
fix(SinglePaymentService): 재고 확인 오류 수정

### DIFF
--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/repository/KakaoPaymentRedisRepository.java
@@ -130,10 +130,14 @@ public class KakaoPaymentRedisRepository {
         redisTemplate.opsForValue().increment(key, quantity);
     }
 
-    public int getRemainderProductQuantity(String productName) {
+    /**
+     * 상품 재고 반환
+     *
+     * @param productName 상품 이름
+     * @return 재고수량
+     */
+    public String getRemainderProductQuantity(String productName) {
         String key = REMAINDER_PRODUCT_KEY_PREFIX + productName;
-        String remainderQuantity = redisTemplate.opsForValue().get(key);
-
-        return remainderQuantity == null ? 0 : Integer.parseInt(remainderQuantity);
+        return redisTemplate.opsForValue().get(key);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#423 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- Redis에 저장이 안되어있고, DB에는 있을 때 재고 없음 오류 발생 수정
  - Redis에서 값이 null일 때 DB확인 후 Redis에 저장

## 🔧 앞으로의 과제 **(Optional)**

- 게이지 및 할인율
