### PR TITLE
docs(SinglePayControllerSwagger): 결제 성공,취소,실패에 대한 Swagger 가시화

### DIFF
--- a/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayControllerSwagger.java
@@ -31,17 +31,17 @@ public interface SinglePayControllerSwagger {
     ResponseEntity<ResponseDTO> deliveryPaymentRequest(@RequestBody DeliveryPaymentRequestDTO paymentRequestDTO,
                                                        @AuthenticationPrincipal MemberDTO memberDTO);
 
-    @Operation(summary = "결제 성공", description = "결제 성공 API", hidden = true)
+    @Operation(summary = "결제 성공", description = "결제 성공 API")
     void successPaymentRequest(@RequestParam("pg_token") String pgToken,
                                @RequestParam("memberId") Long memberId);
 
-    @Operation(summary = "결제 취소", description = "결제 취소 API", hidden = true)
+    @Operation(summary = "결제 취소", description = "결제 취소 API")
     @ApiResponse(responseCode = "200", description = "결제 취소")
     void cancelPaymentRequest(@RequestParam("memberId") Long memberId,
                               @RequestParam("productName") String productName,
                               @RequestParam("quantity") int quantity);
 
-    @Operation(summary = "결제 실패", description = "결제 실패 API", hidden = true)
+    @Operation(summary = "결제 실패", description = "결제 실패 API")
     @ApiResponse(responseCode = "402", description = "결제 실패")
     void failPaymentRequest(@RequestParam("memberId") Long memberId,
                             @RequestParam("productName") String productName,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#433 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 결제 성공,취소,실패에 대한 Swagger 가시화

## 🌄 이미지 첨부 **(Optional)**

![스크린샷 2025-02-27 오후 11 09 30](https://github.com/user-attachments/assets/b369b94a-79f9-495c-a8af-b34d285b9ad4)


## 🔧 앞으로의 과제 **(Optional)**

- 포인트백