### PR TITLE
Fix : Redis 캐싱된 PointPromotion 객체의 직렬 /역직렬화 문제 í해결

### DIFF
--- a/src/main/java/com/codenear/butterfly/promotion/application/PromotionDataAccess.java
+++ b/src/main/java/com/codenear/butterfly/promotion/application/PromotionDataAccess.java
@@ -15,7 +15,7 @@ public class PromotionDataAccess {
 
     private final PointPromotionRepository pointPromotionRepository;
 
-//    @Cacheable(value = "pointPromotion", key = "#promotionId")
+    @Cacheable(value = "pointPromotion", key = "#promotionId")
     public PointPromotion findPointPromotion(Long promotionId) {
         return pointPromotionRepository.findById(promotionId)
                 .orElseThrow(() -> new PromotionException(SERVER_ERROR, null));

--- a/src/main/java/com/codenear/butterfly/promotion/domain/PointPromotion.java
+++ b/src/main/java/com/codenear/butterfly/promotion/domain/PointPromotion.java
@@ -1,5 +1,6 @@
 package com.codenear.butterfly.promotion.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.validation.constraints.DecimalMin;
@@ -9,7 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Entity
 @SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #443 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- Redis 캐싱된 PointPromotion 객체의 직렬 /역직렬화 문제 해결