### PR TITLE
447 fix 카카오페이 결제

### DIFF
--- a/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
+++ b/src/main/java/com/codenear/butterfly/global/exception/ErrorCode.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
-import static org.springframework.http.HttpStatus.PAYMENT_REQUIRED;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.PAYMENT_REQUIRED;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -38,6 +38,7 @@ public enum ErrorCode {
 
     // 402 (PAYMENT_REQUIRED)
     PAY_FAILED(40200, "결제가 실패하였습니다.", PAYMENT_REQUIRED),
+    PAYMENT_REDIRECT_FAILED(40201, "페이지 이동에 실패하였습니다", PAYMENT_REQUIRED),
 
     // 403 (FORBIDDEN)
     INVALID_EMAIL_OR_PASSWORD(40300, "아이디 혹은 비밀번호가 틀렸습니다.", FORBIDDEN),

--- a/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayController.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayController.java
@@ -1,13 +1,16 @@
 package com.codenear.butterfly.kakaoPay.presentation.singlepay;
 
 import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.kakaoPay.application.OrderDetailsService;
 import com.codenear.butterfly.kakaoPay.application.SinglePaymentService;
 import com.codenear.butterfly.kakaoPay.domain.dto.order.OrderDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.DeliveryPaymentRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.PickupPaymentRequestDTO;
+import com.codenear.butterfly.kakaoPay.exception.KakaoPayException;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/payment")
@@ -42,22 +47,43 @@ public class SinglePayController implements SinglePayControllerSwagger {
     @GetMapping("/success")
     public void successPaymentRequest(
             @RequestParam("pg_token") String pgToken,
-            @RequestParam("memberId") Long memberId) {
+            @RequestParam("memberId") Long memberId,
+            HttpServletResponse response) {
         singlePaymentService.approveResponse(pgToken, memberId);
+
+        try {
+            response.sendRedirect("butterfly://kakaopay/success");
+        } catch (IOException e) {
+            throw new KakaoPayException(ErrorCode.PAYMENT_REDIRECT_FAILED, null);
+        }
     }
 
     @GetMapping("/cancel")
     public void cancelPaymentRequest(@RequestParam("memberId") Long memberId,
                                      @RequestParam("productName") String productName,
-                                     @RequestParam("quantity") int quantity) {
+                                     @RequestParam("quantity") int quantity,
+                                     HttpServletResponse response) {
         singlePaymentService.cancelPayment(memberId, productName, quantity);
+
+        try {
+            response.sendRedirect("butterfly://kakaopay/cancel");
+        } catch (IOException e) {
+            throw new KakaoPayException(ErrorCode.PAYMENT_REDIRECT_FAILED, null);
+        }
     }
 
     @GetMapping("/fail")
     public void failPaymentRequest(@RequestParam("memberId") Long memberId,
                                    @RequestParam("productName") String productName,
-                                   @RequestParam("quantity") int quantity) {
+                                   @RequestParam("quantity") int quantity,
+                                   HttpServletResponse response) {
         singlePaymentService.failPayment(memberId, productName, quantity);
+
+        try {
+            response.sendRedirect("butterfly://kakaopay/fail");
+        } catch (IOException e) {
+            throw new KakaoPayException(ErrorCode.PAYMENT_REDIRECT_FAILED, null);
+        }
     }
 
     @GetMapping("/status")

--- a/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayControllerSwagger.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,19 +34,22 @@ public interface SinglePayControllerSwagger {
 
     @Operation(summary = "결제 성공", description = "결제 성공 API")
     void successPaymentRequest(@RequestParam("pg_token") String pgToken,
-                               @RequestParam("memberId") Long memberId);
+                               @RequestParam("memberId") Long memberId,
+                               HttpServletResponse response);
 
     @Operation(summary = "결제 취소", description = "결제 취소 API")
     @ApiResponse(responseCode = "200", description = "결제 취소")
     void cancelPaymentRequest(@RequestParam("memberId") Long memberId,
                               @RequestParam("productName") String productName,
-                              @RequestParam("quantity") int quantity);
+                              @RequestParam("quantity") int quantity,
+                              HttpServletResponse response);
 
     @Operation(summary = "결제 실패", description = "결제 실패 API")
     @ApiResponse(responseCode = "402", description = "결제 실패")
     void failPaymentRequest(@RequestParam("memberId") Long memberId,
                             @RequestParam("productName") String productName,
-                            @RequestParam("quantity") int quantity);
+                            @RequestParam("quantity") int quantity,
+                            HttpServletResponse response);
 
     @Operation(summary = "결제 상태 조회", description = "결제 상태 조회 API")
     @ApiResponse(responseCode = "200", description = "결제 상태 조회 성공")

--- a/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
@@ -14,6 +14,9 @@ import java.util.Map;
 
 @Component
 public class KakaoPaymentUtil<T> {
+    private final String SUCCESS = "/payment/success?memberId=%s";
+    private final String FAILURE = "/payment/fail?memberId=%s&productName=%s&quantity=%s";
+    private final String CANCEL = "/payment/fail?memberId=%s&productName=%s&quantity=%s";
     @Value("${kakao.payment.cid}")
     private String CID;
 
@@ -44,9 +47,9 @@ public class KakaoPaymentUtil<T> {
         parameters.put("total_amount", paymentRequestDTO.getTotal());
         parameters.put("vat_amount", 0);
         parameters.put("tax_free_amount", 0);
-        parameters.put("approval_url", requestUrl + "/success");
-        parameters.put("cancel_url", requestUrl + "/cancel");
-        parameters.put("fail_url", requestUrl + "/fail");
+        parameters.put("approval_url", requestUrl + String.format(SUCCESS, memberId));
+        parameters.put("cancel_url", requestUrl + String.format(CANCEL, memberId, paymentRequestDTO.getProductName(), paymentRequestDTO.getQuantity()));
+        parameters.put("fail_url", requestUrl + String.format(FAILURE, memberId, paymentRequestDTO.getProductName(), paymentRequestDTO.getQuantity()));
         parameters.put("custom_json", "{\"return_custom_url\":\"butterfly://\"}");
         return parameters;
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#447 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 결제 (성공,실패,취소) 파라미터 변경
- 결제 이후 앱으로 강제 redirect

## 🔧 앞으로의 과제 **(Optional)**

- 상품 이미지 사진 2개 이상으로 처리
