### PR TITLE
Refactor : FCM 토큰 생성 방식 수정

### DIFF
--- a/src/main/java/com/codenear/butterfly/notify/fcm/application/FCMTokenService.java
+++ b/src/main/java/com/codenear/butterfly/notify/fcm/application/FCMTokenService.java
@@ -30,17 +30,15 @@ public class FCMTokenService {
         Member member = memberFacade.getMember(loginMember.getId());
         List<Consent> consents = consentFacade.getConsents(member.getId());
 
-        Optional<FCM> existingFcm = fcmRepository.findByToken(token);
-        FCM fcm;
-        if (existingFcm.isPresent()){
-            fcm = existingFcm.get();
-            fcm.updateLastUsedDate();
-        } else {
-            fcm = createFCM(token, member);
-            subscribeToConsentedTopics(token, consents);
-        }
-        fcmRepository.save(fcm);
+        List<FCM> existingFcm = fcmRepository.findByToken(token);
 
+        for (FCM fcm : existingFcm) {
+            fcmRepository.delete(fcm);
+        }
+
+        FCM fcm = createFCM(token, member);
+        subscribeToConsentedTopics(token, consents);
+        fcmRepository.save(fcm);
     }
 
     protected void subscribeToTopic(Long memberId, String topic) {

--- a/src/main/java/com/codenear/butterfly/notify/fcm/domain/FCM.java
+++ b/src/main/java/com/codenear/butterfly/notify/fcm/domain/FCM.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Builder

--- a/src/main/java/com/codenear/butterfly/notify/fcm/infrastructure/FCMRepository.java
+++ b/src/main/java/com/codenear/butterfly/notify/fcm/infrastructure/FCMRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FCMRepository extends JpaRepository<FCM, Long> {
     List<FCM> findByMemberId(Long memberId);
-    Optional<FCM> findByToken(String Token);
+    List<FCM> findByToken(String token);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #458 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 기존 존재하는 FCM토큰들 삭제 후 재생성
