### PR TITLE
467 fix 카카오페이 결제 간헐적 성공 에러

### DIFF
--- a/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/application/CancelPaymentService.java
@@ -10,12 +10,12 @@ import com.codenear.butterfly.kakaoPay.domain.dto.request.CancelRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.repository.CancelPaymentRepository;
 import com.codenear.butterfly.kakaoPay.domain.repository.KakaoPaymentRedisRepository;
 import com.codenear.butterfly.kakaoPay.domain.repository.OrderDetailsRepository;
-import com.codenear.butterfly.kakaoPay.util.KakaoPayRabbitMQProducer;
 import com.codenear.butterfly.kakaoPay.util.KakaoPaymentUtil;
 import com.codenear.butterfly.member.domain.Member;
 import com.codenear.butterfly.point.domain.Point;
 import com.codenear.butterfly.point.domain.PointRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +29,8 @@ public class CancelPaymentService {
     private final OrderDetailsRepository orderDetailsRepository;
     private final KakaoPaymentUtil<Object> kakaoPaymentUtil;
     private final KakaoPaymentRedisRepository kakaoPaymentRedisRepository;
-    private final KakaoPayRabbitMQProducer rabbitMQProducer;
     private final PointRepository pointRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void cancelKakaoPay(CancelRequestDTO cancelRequestDTO) {
 
@@ -52,7 +52,7 @@ public class CancelPaymentService {
 
         // DB 재고 업데이트를 위해 RabbitMQ 메시지 전송
         InventoryIncreaseMessageDTO message = new InventoryIncreaseMessageDTO(orderDetails.getProductName(), orderDetails.getQuantity());
-        rabbitMQProducer.sendMessage(message);
+        applicationEventPublisher.publishEvent(message);
     }
 
     public void increaseUsePoint(Member member, int usePoint) {

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/rabbitmq/InventoryDecreaseMessageDTO.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/rabbitmq/InventoryDecreaseMessageDTO.java
@@ -1,5 +1,12 @@
 package com.codenear.butterfly.kakaoPay.domain.dto.rabbitmq;
 
-public record InventoryDecreaseMessageDTO(String productName,
-                                          int quantity) {
+import lombok.Builder;
+
+public class InventoryDecreaseMessageDTO extends InventoryMessage {
+
+    @Builder
+    public InventoryDecreaseMessageDTO(String productName, int quantity) {
+        super(productName, quantity);
+    }
+
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/rabbitmq/InventoryIncreaseMessageDTO.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/rabbitmq/InventoryIncreaseMessageDTO.java
@@ -1,5 +1,11 @@
 package com.codenear.butterfly.kakaoPay.domain.dto.rabbitmq;
 
-public record InventoryIncreaseMessageDTO(String productName,
-                                          int quantity) {
+import lombok.Builder;
+
+public class InventoryIncreaseMessageDTO extends InventoryMessage {
+
+    @Builder
+    public InventoryIncreaseMessageDTO(String productName, int quantity) {
+        super(productName, quantity);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/rabbitmq/InventoryMessage.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/domain/dto/rabbitmq/InventoryMessage.java
@@ -1,0 +1,17 @@
+package com.codenear.butterfly.kakaoPay.domain.dto.rabbitmq;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class InventoryMessage {
+    private String productName;
+    private int quantity;
+    
+    public InventoryMessage(String productName, int quantity) {
+        this.productName = productName;
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayController.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/presentation/singlepay/SinglePayController.java
@@ -1,14 +1,12 @@
 package com.codenear.butterfly.kakaoPay.presentation.singlepay;
 
 import com.codenear.butterfly.global.dto.ResponseDTO;
-import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.kakaoPay.application.OrderDetailsService;
 import com.codenear.butterfly.kakaoPay.application.SinglePaymentService;
 import com.codenear.butterfly.kakaoPay.domain.dto.order.OrderDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.DeliveryPaymentRequestDTO;
 import com.codenear.butterfly.kakaoPay.domain.dto.request.PickupPaymentRequestDTO;
-import com.codenear.butterfly.kakaoPay.exception.KakaoPayException;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/payment")
@@ -50,12 +46,6 @@ public class SinglePayController implements SinglePayControllerSwagger {
             @RequestParam("memberId") Long memberId,
             HttpServletResponse response) {
         singlePaymentService.approveResponse(pgToken, memberId);
-
-        try {
-            response.sendRedirect("butterfly://kakaopay/success");
-        } catch (IOException e) {
-            throw new KakaoPayException(ErrorCode.PAYMENT_REDIRECT_FAILED, null);
-        }
     }
 
     @GetMapping("/cancel")
@@ -64,12 +54,6 @@ public class SinglePayController implements SinglePayControllerSwagger {
                                      @RequestParam("quantity") int quantity,
                                      HttpServletResponse response) {
         singlePaymentService.cancelPayment(memberId, productName, quantity);
-
-        try {
-            response.sendRedirect("butterfly://kakaopay/cancel");
-        } catch (IOException e) {
-            throw new KakaoPayException(ErrorCode.PAYMENT_REDIRECT_FAILED, null);
-        }
     }
 
     @GetMapping("/fail")
@@ -78,12 +62,6 @@ public class SinglePayController implements SinglePayControllerSwagger {
                                    @RequestParam("quantity") int quantity,
                                    HttpServletResponse response) {
         singlePaymentService.failPayment(memberId, productName, quantity);
-
-        try {
-            response.sendRedirect("butterfly://kakaopay/fail");
-        } catch (IOException e) {
-            throw new KakaoPayException(ErrorCode.PAYMENT_REDIRECT_FAILED, null);
-        }
     }
 
     @GetMapping("/status")

--- a/src/main/java/com/codenear/butterfly/kakaoPay/util/InventoryMessageEventListener.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/util/InventoryMessageEventListener.java
@@ -1,0 +1,20 @@
+package com.codenear.butterfly.kakaoPay.util;
+
+import com.codenear.butterfly.kakaoPay.domain.dto.rabbitmq.InventoryMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class InventoryMessageEventListener {
+    private final KakaoPayRabbitMQProducer rabbitMQProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleInventoryDecreaseEvent(InventoryMessage message) {
+        rabbitMQProducer.sendMessage(message);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPayRabbitMQConsumer.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPayRabbitMQConsumer.java
@@ -30,15 +30,15 @@ public class KakaoPayRabbitMQConsumer {
     @RabbitHandler
     public void handleInventoryDecrease(InventoryDecreaseMessageDTO message, Channel channel, Message rabbitMessage) {
         try {
-            ProductInventory product = productInventoryRepository.findProductByProductName(message.productName());
+            ProductInventory product = productInventoryRepository.findProductByProductName(message.getProductName());
             // 예약된 재고를 최종 차감
-            product.decreaseQuantity(message.quantity());
-            product.increasePurchaseParticipantCount(message.quantity(), DEFAULT_MAX_PURCHASE_NUM);
+            product.decreaseQuantity(message.getQuantity());
+            product.increasePurchaseParticipantCount(message.getQuantity(), DEFAULT_MAX_PURCHASE_NUM);
 
             // 메시지 처리 성공 시 ack
             channel.basicAck(rabbitMessage.getMessageProperties().getDeliveryTag(), false);
         } catch (Exception e) {
-            restoreMessage("decrease", message.productName(), message.quantity(), channel, rabbitMessage);
+            restoreMessage("decrease", message.getProductName(), message.getQuantity(), channel, rabbitMessage);
         }
     }
 
@@ -50,15 +50,15 @@ public class KakaoPayRabbitMQConsumer {
     @RabbitHandler
     public void handleInventoryIncrease(InventoryIncreaseMessageDTO message, Channel channel, Message rabbitMessage) {
         try {
-            ProductInventory product = productInventoryRepository.findProductByProductName(message.productName());
+            ProductInventory product = productInventoryRepository.findProductByProductName(message.getProductName());
             // 취소된 주문 재고 추가
-            product.increaseQuantity(message.quantity());
-            product.decreasePurchaseParticipantCount(message.quantity(), DEFAULT_MAX_PURCHASE_NUM);
+            product.increaseQuantity(message.getQuantity());
+            product.decreasePurchaseParticipantCount(message.getQuantity(), DEFAULT_MAX_PURCHASE_NUM);
 
             // 메시지 처리 성공 시 ack
             channel.basicAck(rabbitMessage.getMessageProperties().getDeliveryTag(), false);
         } catch (Exception e) {
-            restoreMessage("increase", message.productName(), message.quantity(), channel, rabbitMessage);
+            restoreMessage("increase", message.getProductName(), message.getQuantity(), channel, rabbitMessage);
         }
     }
 

--- a/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
+++ b/src/main/java/com/codenear/butterfly/kakaoPay/util/KakaoPaymentUtil.java
@@ -50,7 +50,7 @@ public class KakaoPaymentUtil<T> {
         parameters.put("approval_url", requestUrl + String.format(SUCCESS, memberId));
         parameters.put("cancel_url", requestUrl + String.format(CANCEL, memberId, paymentRequestDTO.getProductName(), paymentRequestDTO.getQuantity()));
         parameters.put("fail_url", requestUrl + String.format(FAILURE, memberId, paymentRequestDTO.getProductName(), paymentRequestDTO.getQuantity()));
-        parameters.put("custom_json", "{\"return_custom_url\":\"butterfly://kakaopay/success\"}");
+        parameters.put("custom_json", "{\"return_custom_url\":\"butterfly://\"}");
         return parameters;
     }
 

--- a/src/test/java/com/codenear/butterfly/ButterflyApplicationTests.java
+++ b/src/test/java/com/codenear/butterfly/ButterflyApplicationTests.java
@@ -2,12 +2,14 @@ package com.codenear.butterfly;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootTest
+@EnableAsync
 class ButterflyApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#467 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- rabbitMQ 메세지 전송 방법 변경
  - log를 찍었을 때 정상 작동되고, 찍지 않았을 때 간헐적 성공이 일어나 Transaction 문제 해결을 위해 비동기 이벤트 처리 적용 및 트랜잭션 커밋 후 메시지 전송 보장
- return_custom_url 변경 및 success,fail,cancel redirect 제거
  - "butterfly://kakaopay/success를 적용했을 때 자동으로 홈화면으로 가지기 때문에 프론트쪽에서 분기처리 위해 기본 앱스킴으로 변경
