### PR TITLE
494 feat 상품 재입고 알림

### DIFF
--- a/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import static com.codenear.butterfly.consent.domain.ConsentType.MARKETING;
 import static com.codenear.butterfly.notify.NotifyMessage.NEW_PRODUCT;
+import static com.codenear.butterfly.notify.NotifyMessage.RESTOCK_PRODUCT;
 import static com.codenear.butterfly.s3.domain.S3Directory.PRODUCT_IMAGE;
 
 @Service
@@ -75,12 +76,15 @@ public class AdminProductService {
 
     @Transactional
     public void updateProduct(Long id, ProductUpdateRequest request) {
-        Product product = findById(id);
+        ProductInventory product = findById(id);
 
         updateImage(request.getProductImage(), product, ProductImage.ImageType.MAIN);
         updateImage(request.getDescriptionImages(), product, ProductImage.ImageType.DESCRIPTION);
 
         List<Keyword> existingKeywords = keywordRepository.findAllByProductId(id);
+        if (product.getStockQuantity() == 0 && request.getStockQuantity() > 0) {
+            sendRestockNotification(product);
+        }
         product.update(request);
 
         List<Keyword> newKeywords = request.getKeywords().stream()
@@ -187,5 +191,21 @@ public class AdminProductService {
         if (!keywords.isEmpty()) {
             keywordRedisRepository.saveKeyword(keywords);
         }
+    }
+
+    /**
+     * 재입고 알림 발송
+     *
+     * @param product 상품
+     */
+    private void sendRestockNotification(Product product) {
+        product.getRestocks()
+                .forEach(restock -> {
+                    fcmFacade.sendMessage(RESTOCK_PRODUCT, restock.getMember().getId());
+                    restock.sendNotification();
+
+                    product.removeRestock(restock);
+                    restock.getMember().removeRestock(restock);
+                });
     }
 }

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -4,13 +4,29 @@ import com.codenear.butterfly.address.domain.Address;
 import com.codenear.butterfly.consent.domain.Consent;
 import com.codenear.butterfly.global.domain.BaseEntity;
 import com.codenear.butterfly.notify.alarm.domain.Alarm;
+import com.codenear.butterfly.notify.alarm.domain.Restock;
 import com.codenear.butterfly.point.domain.Point;
 import com.codenear.butterfly.product.domain.Favorite;
 import com.codenear.butterfly.product.domain.Product;
 import com.codenear.butterfly.product.domain.ProductInventory;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import net.minidev.json.annotate.JsonIgnore;
 
 import java.util.ArrayList;
@@ -66,6 +82,9 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnore
     private List<Alarm> alarms = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Restock> restocks = new ArrayList<>();
 
     @JsonProperty("deleted")
     private boolean isDeleted;

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -123,4 +123,8 @@ public class Member extends BaseEntity {
     public void addRestock(Restock restock) {
         this.restocks.add(restock);
     }
+
+    public void removeRestock(Restock restock) {
+        this.restocks.remove(restock);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/member/domain/Member.java
+++ b/src/main/java/com/codenear/butterfly/member/domain/Member.java
@@ -119,4 +119,8 @@ public class Member extends BaseEntity {
     public void restore() {
         this.isDeleted = false;
     }
+
+    public void addRestock(Restock restock) {
+        this.restocks.add(restock);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/notify/NotifyMessage.java
+++ b/src/main/java/com/codenear/butterfly/notify/NotifyMessage.java
@@ -8,9 +8,9 @@ import lombok.Getter;
 
 import java.util.Arrays;
 
+import static com.codenear.butterfly.consent.domain.ConsentType.CUSTOMER_SUPPORT;
 import static com.codenear.butterfly.consent.domain.ConsentType.DELIVERY_NOTIFICATION;
 import static com.codenear.butterfly.consent.domain.ConsentType.MARKETING;
-import static com.codenear.butterfly.consent.domain.ConsentType.CUSTOMER_SUPPORT;
 import static com.codenear.butterfly.consent.domain.ConsentType.POINT_BACK;
 import static com.codenear.butterfly.global.exception.ErrorCode.NOTIFY_MESSAGE_NOT_FOUND;
 
@@ -25,7 +25,8 @@ public enum NotifyMessage {
     INQUIRY_ANSWERED(5, "QnA 답변", "\uD83D\uDCEC 답변이 도착했습니다!", "문의하신 내용에 답변이 도착했어요. 지금 바로 확인해 보세요. \uD83D\uDCE8", CUSTOMER_SUPPORT),
     CITATION_PROMOTION(6, "프로모션 적립", "\uD83C\uDF89 전화번호 인증 완료! ", "1,000 포인트가 지급되었어요! 지금 바로 사용해 보세요 \uD83E\uDD29", MARKETING),
     ORDER_CANCELED(7, "주문 취소", "\uD83D\uDCEC 주문하신 상품이 취소되었습니다.", "고객님의 주문이 취소되었어요. \uD83D\uDCEC", MARKETING),
-    ORDER_SUCCESS(8, "결제 완료", "\uD83E\uDD73 결제가 완료되었습니다.", "주문해주셔서 감사합니다. 꼼꼼히 확인해서 준비해드리겠습니다! \uD83D\uDE0A", MARKETING);
+    ORDER_SUCCESS(8, "결제 완료", "\uD83E\uDD73 결제가 완료되었습니다.", "주문해주셔서 감사합니다. 꼼꼼히 확인해서 준비해드리겠습니다! \uD83D\uDE0A", MARKETING),
+    RESTOCK_PRODUCT(9, "상품 재입고", "\uD83C\uDF81 상품이 재입고 되었습니다.", "신청하신 상품이 재입고 되었어요. 지금 확인하고 가장 먼저 만나보세요 \uD83C\uDF1F", MARKETING);
 
     private final int id;
     private final String title;

--- a/src/main/java/com/codenear/butterfly/notify/alarm/application/RestockService.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/application/RestockService.java
@@ -1,0 +1,80 @@
+package com.codenear.butterfly.notify.alarm.application;
+
+import com.codenear.butterfly.global.exception.ErrorCode;
+import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.member.domain.repository.member.MemberRepository;
+import com.codenear.butterfly.member.exception.MemberException;
+import com.codenear.butterfly.notify.alarm.domain.Restock;
+import com.codenear.butterfly.notify.alarm.domain.dto.RestockResponseDTO;
+import com.codenear.butterfly.notify.alarm.infrastructure.RestockRepository;
+import com.codenear.butterfly.product.domain.Product;
+import com.codenear.butterfly.product.domain.repository.ProductRepository;
+import com.codenear.butterfly.product.exception.ProductException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RestockService {
+    private final RestockRepository restockRepository;
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 재입고 알림 저장
+     *
+     * @param memberId  사용자 아이디
+     * @param productId 상품 아이디
+     * @return RestockResponseDTO
+     */
+    public RestockResponseDTO createRestock(final Long memberId, final Long productId) {
+        Member member = validateMember(memberId);
+        Product product = validateProduct(productId);
+        Restock restock = alreadyRestock(member, product);
+
+        if (restock != null) {
+            restock.applyRestockNotification();
+            return RestockResponseDTO.from(restock);
+        }
+
+        restock = Restock.create(member, product);
+        restockRepository.save(restock);
+
+        return RestockResponseDTO.from(restock);
+    }
+
+    /**
+     * 등록되어있는 회원 검증
+     *
+     * @param memberId 사용자 아이디
+     * @return Member
+     */
+    private Member validateMember(final Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND, "회원을 찾을 수 없습니다."));
+    }
+
+    /**
+     * 등록되어있는 상품 검증
+     *
+     * @param productId 상품 아이디
+     * @return Product
+     */
+    private Product validateProduct(final Long productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException(ErrorCode.PRODUCT_NOT_FOUND, "등록된 상품이 없습니다."));
+    }
+
+    /**
+     * 이전에 신청한 내역이 있는지 확인
+     *
+     * @param member  사용자
+     * @param product 상품
+     * @return Restock
+     */
+    private Restock alreadyRestock(final Member member, final Product product) {
+        return restockRepository.findByMemberAndProduct(member, product);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/notify/alarm/application/RestockService.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/application/RestockService.java
@@ -46,6 +46,20 @@ public class RestockService {
     }
 
     /**
+     * 재입고 신청 현황
+     *
+     * @param memberId  사용자 아이디
+     * @param productId 상품 아이디
+     * @return boolean
+     */
+    public boolean existsRestock(final Long memberId, final Long productId) {
+        Member member = validateMember(memberId);
+        Product product = validateProduct(productId);
+
+        return restockRepository.existsByMemberAndProductAndIsNotifiedFalse(member, product);
+    }
+
+    /**
      * 등록되어있는 회원 검증
      *
      * @param memberId 사용자 아이디

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
@@ -36,7 +36,7 @@ public class Restock {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    private boolean isNotified;
+    private Boolean isNotified;
 
     private Restock(final Member member, final Product product) {
         this.member = member;

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
@@ -44,11 +44,19 @@ public class Restock {
         this.isNotified = false;
     }
 
-    public static Restock of(final Member member, final Product product) {
+    public static Restock create(final Member member, final Product product) {
         Restock restock = new Restock(member, product);
         member.addRestock(restock);
         product.addRestock(restock);
 
         return restock;
+    }
+
+    public void sendNotification() {
+        this.isNotified = true;
+    }
+
+    public void applyRestockNotification() {
+        this.isNotified = false;
     }
 }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
@@ -1,0 +1,41 @@
+package com.codenear.butterfly.notify.alarm.domain;
+
+import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.product.domain.Product;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "product_id"})
+        }
+)
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Restock {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private boolean isNotified;
+
+}

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/Restock.java
@@ -38,4 +38,17 @@ public class Restock {
 
     private boolean isNotified;
 
+    private Restock(final Member member, final Product product) {
+        this.member = member;
+        this.product = product;
+        this.isNotified = false;
+    }
+
+    public static Restock of(final Member member, final Product product) {
+        Restock restock = new Restock(member, product);
+        member.addRestock(restock);
+        product.addRestock(restock);
+
+        return restock;
+    }
 }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/domain/dto/RestockResponseDTO.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/domain/dto/RestockResponseDTO.java
@@ -1,0 +1,11 @@
+package com.codenear.butterfly.notify.alarm.domain.dto;
+
+import com.codenear.butterfly.notify.alarm.domain.Restock;
+
+public record RestockResponseDTO(Long memberId,
+                                 Long productId) {
+
+    public static RestockResponseDTO from(Restock restock) {
+        return new RestockResponseDTO(restock.getMember().getId(), restock.getProduct().getId());
+    }
+}

--- a/src/main/java/com/codenear/butterfly/notify/alarm/infrastructure/RestockRepository.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/infrastructure/RestockRepository.java
@@ -1,0 +1,12 @@
+package com.codenear.butterfly.notify.alarm.infrastructure;
+
+import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.notify.alarm.domain.Restock;
+import com.codenear.butterfly.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestockRepository extends JpaRepository<Restock, Long> {
+    Restock findByMemberAndProduct(Member member, Product product);
+
+    boolean existsByMemberAndProduct(Member member, Product product);
+}

--- a/src/main/java/com/codenear/butterfly/notify/alarm/infrastructure/RestockRepository.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/infrastructure/RestockRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RestockRepository extends JpaRepository<Restock, Long> {
     Restock findByMemberAndProduct(Member member, Product product);
 
-    boolean existsByMemberAndProduct(Member member, Product product);
+    boolean existsByMemberAndProductAndIsNotifiedFalse(Member member, Product product);
 }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockController.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockController.java
@@ -1,0 +1,28 @@
+package com.codenear.butterfly.notify.alarm.presentation;
+
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.global.util.ResponseUtil;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.notify.alarm.application.RestockService;
+import com.codenear.butterfly.notify.alarm.domain.dto.RestockResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notify/alarm")
+public class RestockController implements RestockControllerSwagger {
+    private final RestockService restockService;
+
+    @PostMapping("/{product_id}/restock")
+    public ResponseEntity<ResponseDTO> createRestock(@AuthenticationPrincipal MemberDTO member,
+                                                     @PathVariable(name = "product_id") Long productId) {
+        RestockResponseDTO applyRestock = restockService.createRestock(member.getId(), productId);
+        return ResponseUtil.createSuccessResponse(applyRestock);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockController.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockController.java
@@ -8,6 +8,7 @@ import com.codenear.butterfly.notify.alarm.domain.dto.RestockResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,5 +25,11 @@ public class RestockController implements RestockControllerSwagger {
                                                      @PathVariable(name = "product_id") Long productId) {
         RestockResponseDTO applyRestock = restockService.createRestock(member.getId(), productId);
         return ResponseUtil.createSuccessResponse(applyRestock);
+    }
+
+    @GetMapping("/{product_id}/restock")
+    public ResponseEntity<ResponseDTO> existsRestock(MemberDTO member, Long productId) {
+        boolean isRestock = restockService.existsRestock(member.getId(), productId);
+        return ResponseUtil.createSuccessResponse(isRestock);
     }
 }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockControllerSwagger.java
@@ -26,4 +26,13 @@ public interface RestockControllerSwagger {
     })
     ResponseEntity<ResponseDTO> createRestock(@AuthenticationPrincipal MemberDTO member,
                                               @PathVariable(name = "product_id") Long productId);
+
+    @Operation(summary = "재입고 신청 현황", description = "해당 상품에 대한 재입고 신청이 되어있는지 확인")
+    @ApiResponses({
+            @ApiResponse(responseCode = "body", description = "응답 메시지 예시",
+                    content = @Content(schema = @Schema(implementation = Boolean.class))),
+            @ApiResponse(responseCode = "200", description = "Success")
+    })
+    ResponseEntity<ResponseDTO> existsRestock(@AuthenticationPrincipal MemberDTO member,
+                                              @PathVariable(name = "product_id") Long productId);
 }

--- a/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/notify/alarm/presentation/RestockControllerSwagger.java
@@ -1,0 +1,29 @@
+package com.codenear.butterfly.notify.alarm.presentation;
+
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.member.domain.dto.MemberDTO;
+import com.codenear.butterfly.notify.alarm.domain.dto.RestockResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Alarm", description = "**재입고 알림 API**")
+public interface RestockControllerSwagger {
+    @Operation(summary = "재입고 신청", description = "Sold Out 된 상품의 재입고 알림 신청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "body", description = "응답 메시지 예시",
+                    content = @Content(schema = @Schema(implementation = RestockResponseDTO.class))),
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "40400", description = "등록된 상품 정보가 없을 때"),
+            @ApiResponse(responseCode = "40402", description = "등록된 회원 정보가 없을 때")
+
+    })
+    ResponseEntity<ResponseDTO> createRestock(@AuthenticationPrincipal MemberDTO member,
+                                              @PathVariable(name = "product_id") Long productId);
+}

--- a/src/main/java/com/codenear/butterfly/product/domain/Product.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/Product.java
@@ -142,5 +142,9 @@ public abstract class Product {
         keywords.addAll(keywordsToAdd);
     }
 
+    public void addRestock(Restock restock) {
+        this.restocks.add(restock);
+    }
+
     public abstract void update(ProductUpdateRequest request);
 }

--- a/src/main/java/com/codenear/butterfly/product/domain/Product.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/Product.java
@@ -2,6 +2,7 @@ package com.codenear.butterfly.product.domain;
 
 import com.codenear.butterfly.admin.products.dto.ProductCreateRequest;
 import com.codenear.butterfly.admin.products.dto.ProductUpdateRequest;
+import com.codenear.butterfly.notify.alarm.domain.Restock;
 import com.codenear.butterfly.product.util.CategoryConverter;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -77,6 +78,9 @@ public abstract class Product {
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Where(clause = "image_type = 'MAIN'")
     private List<ProductImage> productImage = new ArrayList<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Restock> restocks = new ArrayList<>();
 
     protected Product(ProductCreateRequest createRequest,
                       List<ProductImage> productImage,

--- a/src/main/java/com/codenear/butterfly/product/domain/Product.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/Product.java
@@ -146,5 +146,9 @@ public abstract class Product {
         this.restocks.add(restock);
     }
 
+    public void removeRestock(Restock restock) {
+        this.restocks.remove(restock);
+    }
+
     public abstract void update(ProductUpdateRequest request);
 }

--- a/src/test/java/com/codenear/butterfly/notify/alarm/application/RestockServiceTest.java
+++ b/src/test/java/com/codenear/butterfly/notify/alarm/application/RestockServiceTest.java
@@ -1,0 +1,182 @@
+package com.codenear.butterfly.notify.alarm.application;
+
+import com.codenear.butterfly.admin.products.application.AdminProductService;
+import com.codenear.butterfly.admin.products.dto.ProductUpdateRequest;
+import com.codenear.butterfly.global.exception.ErrorCode;
+import com.codenear.butterfly.member.domain.Member;
+import com.codenear.butterfly.member.domain.repository.member.MemberRepository;
+import com.codenear.butterfly.member.exception.MemberException;
+import com.codenear.butterfly.notify.alarm.domain.Restock;
+import com.codenear.butterfly.notify.alarm.domain.dto.RestockResponseDTO;
+import com.codenear.butterfly.notify.alarm.infrastructure.RestockRepository;
+import com.codenear.butterfly.notify.fcm.application.FCMFacade;
+import com.codenear.butterfly.payment.domain.repository.PaymentRedisRepository;
+import com.codenear.butterfly.product.domain.ProductImage;
+import com.codenear.butterfly.product.domain.ProductInventory;
+import com.codenear.butterfly.product.domain.repository.KeywordRedisRepository;
+import com.codenear.butterfly.product.domain.repository.KeywordRepository;
+import com.codenear.butterfly.product.domain.repository.ProductImageRepository;
+import com.codenear.butterfly.product.domain.repository.ProductInventoryRepository;
+import com.codenear.butterfly.product.domain.repository.ProductRepository;
+import com.codenear.butterfly.product.exception.ProductException;
+import com.codenear.butterfly.s3.application.S3Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.codenear.butterfly.notify.NotifyMessage.RESTOCK_PRODUCT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RestockServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private ProductInventoryRepository productInventoryRepository;
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private RestockRepository restockRepository;
+    @Mock
+    private ProductImageRepository productImageRepository;
+    @Mock
+    private FCMFacade fcmFacade;
+    @Mock
+    private S3Service s3Service;
+    @Mock
+    private KeywordRepository keywordRepository;
+    @Mock
+    private KeywordRedisRepository keywordRedisRepository;
+    @Mock
+    private PaymentRedisRepository paymentRedisRepository;
+
+    @InjectMocks
+    private RestockService restockService;
+
+    @InjectMocks
+    private AdminProductService adminProductService;
+
+    private Long memberId = 1L;
+    private Long productId = 1L;
+    private Member member;
+    private ProductInventory product;
+
+    @BeforeEach
+    void setup() {
+        member = mock(Member.class);
+        product = mock(ProductInventory.class);
+    }
+
+    @Test
+    void 새로운_재입고_알림을_신청한다() {
+        //given
+        when(restockRepository.findByMemberAndProduct(member, product)).thenReturn(null);
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+
+        // when
+        RestockResponseDTO result = restockService.createRestock(memberId, productId);
+
+        // then
+        assertNotNull(result);
+        verify(restockRepository).save(any());
+    }
+
+    @Test
+    void 이전에_신청한상품에_재신청_한다() {
+        // given
+        Restock existingRestock = mock(Restock.class);
+        when(restockRepository.findByMemberAndProduct(member, product)).thenReturn(existingRestock);
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(existingRestock.getMember()).thenReturn(member);
+        when(existingRestock.getProduct()).thenReturn(product);
+
+        // when
+        restockService.createRestock(memberId, productId);
+
+        // then
+        verify(existingRestock).applyRestockNotification();
+        verify(restockRepository, never()).save(any());
+    }
+
+    @Test
+    void 재입고_알림을_발송한다() {
+        // given
+        Restock restock = mock(Restock.class);
+        ProductUpdateRequest request = mock(ProductUpdateRequest.class);
+
+        MultipartFile dummyFile = mock(MultipartFile.class);
+        when(dummyFile.isEmpty()).thenReturn(false);
+
+        when(restock.getMember()).thenReturn(member);
+        when(request.getProductImage()).thenReturn(List.of(dummyFile));
+        when(request.getDescriptionImages()).thenReturn(List.of(dummyFile));
+
+        when(request.getStockQuantity()).thenReturn(10);
+        when(product.getStockQuantity()).thenReturn(0);
+        when(product.getRestocks()).thenReturn(List.of(restock));
+        when(product.getId()).thenReturn(productId);
+
+        when(productImageRepository.findAllByProductIdAndImageType(productId, ProductImage.ImageType.MAIN)).thenReturn(List.of());
+        when(productImageRepository.findAllByProductIdAndImageType(productId, ProductImage.ImageType.DESCRIPTION)).thenReturn(List.of());
+        when(productInventoryRepository.findById(productId)).thenReturn(Optional.of(product));
+
+        // when
+        adminProductService.updateProduct(productId, request);
+
+        // then
+        verify(fcmFacade).sendMessage(RESTOCK_PRODUCT, member.getId());
+        verify(restock).sendNotification();
+        verify(product).removeRestock(restock);
+        verify(member).removeRestock(restock);
+    }
+
+    @Test
+    void 재입고_신청_현황을_반환한다() {
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(restockRepository.existsByMemberAndProductAndIsNotifiedFalse(member, product)).thenReturn(true);
+
+        boolean result = restockService.existsRestock(memberId, productId);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 존재하지_않는_회원이면_예외발생() {
+        // when
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> restockService.createRestock(memberId, productId))
+                .isInstanceOf(MemberException.class)
+                .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 존재하지_않는_상품이면_예외발생() {
+        // when
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(productRepository.findById(productId)).thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> restockService.createRestock(memberId, productId))
+                .isInstanceOf(ProductException.class)
+                .hasMessageContaining(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#494 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 재입고 테이블 생성
- 재입고 신청, 재입고 현황 확인
- product의 stockQuantity가 0(sold out)에서 재고가 추가될 때 알림 발송

## 🌄 이미지 첨부 **(Optional)**
<img src="https://github.com/user-attachments/assets/d9ea4d19-442f-4290-996a-bbc310e0b4b5" width="50%" height="50%"/>

## 🔧 앞으로의 과제 **(Optional)**

- 카카오톡 배달 동시 알림 서비스