### PR TITLE
542 feat 소상공인 물품 등록

### DIFF
--- a/src/main/java/com/codenear/butterfly/admin/AdminController.java
+++ b/src/main/java/com/codenear/butterfly/admin/AdminController.java
@@ -1,17 +1,75 @@
 package com.codenear.butterfly.admin;
 
+import com.codenear.butterfly.admin.products.dto.ScheduleUpdateRequest;
+import com.codenear.butterfly.global.dto.ResponseDTO;
+import com.codenear.butterfly.global.util.ResponseUtil;
+import com.codenear.butterfly.product.domain.dto.MealSchedulerInfoDTO;
+import com.codenear.butterfly.product.util.SBProductScheduler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {
+    private final SBProductScheduler sbProductScheduler;
 
     @GetMapping
-    public String showAdminPage() {
+    public String showAdminPage(Model model) {
+        MealSchedulerInfoDTO scheduleInfo = sbProductScheduler.getCurrentScheduleInfo();
+        model.addAttribute("scheduleInfo", scheduleInfo);
         return "adminDashboard";
+    }
+
+    /**
+     * 현재 스케줄러 상태 조회
+     */
+    @GetMapping("/scheduler/status")
+    public ResponseEntity<ResponseDTO> getSchedulerStatus() {
+        MealSchedulerInfoDTO scheduleInfo = sbProductScheduler.getCurrentScheduleInfo();
+        return ResponseUtil.createSuccessResponse("스케줄러 상태 조회 성공", scheduleInfo);
+    }
+
+    /**
+     * 점심 시작 스케줄러 변경
+     */
+    @PostMapping("/schedule/lunch")
+    public String updateLunchSchedule(
+            @ModelAttribute ScheduleUpdateRequest scheduleUpdateRequest,
+            RedirectAttributes redirectAttributes) {
+        try {
+            sbProductScheduler.updateLunchSchedule(scheduleUpdateRequest);
+            redirectAttributes.addFlashAttribute("message", "점심 스케줄이 성공적으로 변경되었습니다:");
+            redirectAttributes.addFlashAttribute("messageType", "success");
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("message", "잘못된 cron 표현식입니다: " + e.getMessage());
+            redirectAttributes.addFlashAttribute("messageType", "error");
+        }
+        return "redirect:/admin";
+    }
+
+    /**
+     * 저녁 스케줄 변경
+     */
+    @PostMapping("/schedule/dinner")
+    public String updateDinnerSchedule(
+            @ModelAttribute ScheduleUpdateRequest scheduleUpdateRequest,
+            RedirectAttributes redirectAttributes) {
+        try {
+            sbProductScheduler.updateDinnerSchedule(scheduleUpdateRequest);
+            redirectAttributes.addFlashAttribute("message", "저녁 스케줄이 성공적으로 변경되었습니다:");
+            redirectAttributes.addFlashAttribute("messageType", "success");
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("message", "잘못된 cron 표현식입니다: " + e.getMessage());
+            redirectAttributes.addFlashAttribute("messageType", "error");
+        }
+        return "redirect:/admin";
     }
 }

--- a/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
@@ -11,6 +11,7 @@ import com.codenear.butterfly.product.domain.Keyword;
 import com.codenear.butterfly.product.domain.Product;
 import com.codenear.butterfly.product.domain.ProductImage;
 import com.codenear.butterfly.product.domain.ProductInventory;
+import com.codenear.butterfly.product.domain.SBMealType;
 import com.codenear.butterfly.product.domain.SmallBusinessProduct;
 import com.codenear.butterfly.product.domain.repository.FavoriteRepository;
 import com.codenear.butterfly.product.domain.repository.KeywordRedisRepository;
@@ -85,15 +86,25 @@ public class AdminProductService {
     }
 
     /**
-     * 전체 상품 조회
+     * ALL : 전체 상품 조회 / LUNCH : 소상공인 점심 상품 조회 / DINNER : 소상공인 저녁 상품 조회
      *
-     * @return 상품 목록 전체
+     * @return 상품 목록
      */
     public List<ProductInventory> loadAllProducts(String productType) {
         if ("ALL".equals(productType)) {
             return productRepository.findAll();
         }
         return productRepository.findByProductType(productType);
+    }
+
+    /**
+     * MealType별 상품 목록 조회
+     *
+     * @param mealType 판매 시간 (LUNCH,DINNER)
+     * @return 점심/저녁 상품 목록
+     */
+    public List<Long> loadSmallBusinessProductsByMealType(SBMealType mealType) {
+        return productRepository.findIdsByMealType(mealType);
     }
 
     @Transactional
@@ -107,7 +118,7 @@ public class AdminProductService {
         if (product.getStockQuantity() == 0 && request.getStockQuantity() > 0) {
             sendRestockNotification(product);
         }
-        
+
         if (product instanceof SmallBusinessProduct smallBusinessProduct) {
             smallBusinessProduct.update(request);
         } else {

--- a/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
@@ -84,8 +84,16 @@ public class AdminProductService {
         saveKeywordForRedis(keywords);
     }
 
-    public List<ProductInventory> loadAllProducts() {
-        return productRepository.findAll();
+    /**
+     * 전체 상품 조회
+     *
+     * @return 상품 목록 전체
+     */
+    public List<ProductInventory> loadAllProducts(String productType) {
+        if ("ALL".equals(productType)) {
+            return productRepository.findAll();
+        }
+        return productRepository.findByProductType(productType);
     }
 
     @Transactional

--- a/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/application/AdminProductService.java
@@ -107,7 +107,13 @@ public class AdminProductService {
         if (product.getStockQuantity() == 0 && request.getStockQuantity() > 0) {
             sendRestockNotification(product);
         }
-        product.update(request);
+        
+        if (product instanceof SmallBusinessProduct smallBusinessProduct) {
+            smallBusinessProduct.update(request);
+        } else {
+            product.update(request);
+        }
+
         List<Keyword> newKeywords = request.getKeywords().stream()
                 .map(Keyword::new)
                 .toList();
@@ -123,7 +129,7 @@ public class AdminProductService {
                 .map(Keyword::getKeyword)
                 .collect(Collectors.joining(", "));
 
-        return new ProductEditResponse(product, keywordString);
+        return ProductEditResponse.from(product, keywordString);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/codenear/butterfly/admin/products/dto/ProductCreateRequest.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/dto/ProductCreateRequest.java
@@ -1,5 +1,6 @@
 package com.codenear.butterfly.admin.products.dto;
 
+import com.codenear.butterfly.product.domain.SBMealType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,6 +17,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductCreateRequest {
+    private String productType;
     private List<MultipartFile> productImage;
     private String productName;
     private String companyName;
@@ -33,5 +35,6 @@ public class ProductCreateRequest {
     private String deliveryInformation;
     private List<MultipartFile> descriptionImages;
     private List<DiscountRateRequest> discountRates = new ArrayList<DiscountRateRequest>();
+    private SBMealType orderType;
 }
 

--- a/src/main/java/com/codenear/butterfly/admin/products/dto/ProductCreateRequest.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/dto/ProductCreateRequest.java
@@ -35,6 +35,6 @@ public class ProductCreateRequest {
     private String deliveryInformation;
     private List<MultipartFile> descriptionImages;
     private List<DiscountRateRequest> discountRates = new ArrayList<DiscountRateRequest>();
-    private SBMealType orderType;
+    private SBMealType mealType;
 }
 

--- a/src/main/java/com/codenear/butterfly/admin/products/dto/ProductEditResponse.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/dto/ProductEditResponse.java
@@ -1,10 +1,23 @@
 package com.codenear.butterfly.admin.products.dto;
 
 import com.codenear.butterfly.product.domain.Product;
+import com.codenear.butterfly.product.domain.SBMealType;
+import com.codenear.butterfly.product.domain.SmallBusinessProduct;
 
 public record ProductEditResponse(
         Product product,
-        String keywordString
+        String keywordString,
+        String productType,
+        SBMealType mealType
 ) {
+    public static ProductEditResponse from(Product product, String keywordString) {
+        String type = "INVENTORY"; // 기본값
+        SBMealType mealType = null;
 
+        if (product instanceof SmallBusinessProduct smallBusinessProduct) {
+            type = "SMALL_BUSINESS";
+            mealType = smallBusinessProduct.getOrderType();
+        }
+        return new ProductEditResponse(product, keywordString, type, mealType);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/admin/products/dto/ProductEditResponse.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/dto/ProductEditResponse.java
@@ -16,8 +16,9 @@ public record ProductEditResponse(
 
         if (product instanceof SmallBusinessProduct smallBusinessProduct) {
             type = "SMALL_BUSINESS";
-            mealType = smallBusinessProduct.getOrderType();
+            mealType = smallBusinessProduct.getMealType();
         }
+
         return new ProductEditResponse(product, keywordString, type, mealType);
     }
 }

--- a/src/main/java/com/codenear/butterfly/admin/products/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/dto/ProductUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.codenear.butterfly.admin.products.dto;
 
 import com.codenear.butterfly.product.domain.Category;
+import com.codenear.butterfly.product.domain.SBMealType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductUpdateRequest {
+    private String productType;
     private String productName;
     private String companyName;
     private String description;
@@ -33,6 +35,7 @@ public class ProductUpdateRequest {
     private List<String> keywords;
     private List<DiscountRateRequest> discountRates;
     private List<MultipartFile> descriptionImages;
+    private SBMealType mealType;
 
     public Category getCategory() {
         return Category.fromValue(category);

--- a/src/main/java/com/codenear/butterfly/admin/products/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/dto/ScheduleUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.codenear.butterfly.admin.products.dto;
+
+public record ScheduleUpdateRequest(String cronStartExpression,
+                                    String cronEndExpression) {
+}

--- a/src/main/java/com/codenear/butterfly/admin/products/presentation/AdminProductsController.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/presentation/AdminProductsController.java
@@ -70,6 +70,8 @@ public class AdminProductsController {
         model.addAttribute("product", response.product());
         model.addAttribute("keywordString", response.keywordString());
         model.addAttribute("categories", adminProductService.getCategories());
+        model.addAttribute("productType", response.productType());
+        model.addAttribute("mealType", response.mealType());
         return "admin/products/product-edit";
     }
 

--- a/src/main/java/com/codenear/butterfly/admin/products/presentation/AdminProductsController.java
+++ b/src/main/java/com/codenear/butterfly/admin/products/presentation/AdminProductsController.java
@@ -8,14 +8,19 @@ import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.product.domain.Category;
-import com.codenear.butterfly.product.domain.Product;
 import com.codenear.butterfly.product.domain.ProductInventory;
 import com.codenear.butterfly.product.exception.ProductException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
@@ -49,11 +54,13 @@ public class AdminProductsController {
     }
 
     @GetMapping
-    public String showProductList(Model model) {
-        List<ProductInventory> products = adminProductService.loadAllProducts();
+    public String showProductList(Model model,
+                                  @RequestParam(name = "type", required = false, defaultValue = "ALL") String productType) {
+        List<ProductInventory> products = adminProductService.loadAllProducts(productType);
         List<Category> categories = adminProductService.getCategories();
         model.addAttribute("products", products);
         model.addAttribute("categories", categories);
+        model.addAttribute("selectedType", productType);
         return "admin/products/product-list";
     }
 

--- a/src/main/java/com/codenear/butterfly/global/config/RedisConfig.java
+++ b/src/main/java/com/codenear/butterfly/global/config/RedisConfig.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,11 +21,8 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.cache.CacheManager;
 
 import java.util.HashMap;
-
-import java.time.Duration;
 import java.util.Map;
 
 @Configuration
@@ -66,6 +64,18 @@ public class RedisConfig {
 
         redisTemplate.afterPropertiesSet();
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> redisTemplateByNumeric(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
     }
 
     private RedisCacheConfiguration redisCacheConfiguration() {

--- a/src/main/java/com/codenear/butterfly/product/application/MealScheduleService.java
+++ b/src/main/java/com/codenear/butterfly/product/application/MealScheduleService.java
@@ -1,0 +1,43 @@
+package com.codenear.butterfly.product.application;
+
+import com.codenear.butterfly.product.domain.dto.MealScheduleTimeDTO;
+import com.codenear.butterfly.product.domain.dto.MealSchedulerInfoDTO;
+import com.codenear.butterfly.product.util.SBProductScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MealScheduleService {
+    private final SBProductScheduler sbProductScheduler;
+
+    /**
+     * 현재 스케줄러 시간 정보
+     *
+     * @return 식사 시간 정보
+     */
+    public MealScheduleTimeDTO getMealScheduleTime() {
+        MealSchedulerInfoDTO mealSchedule = sbProductScheduler.getCurrentScheduleInfo();
+
+        return MealScheduleTimeDTO.builder()
+                .lunchStartHour(getCronHour(mealSchedule.lunchStartCron()))
+                .lunchStartMinute(getCronMinute(mealSchedule.lunchStartCron()))
+                .lunchEndHour(getCronHour(mealSchedule.lunchEndCron()))
+                .lunchEndMinute(getCronMinute(mealSchedule.lunchEndCron()))
+                .dinnerStartHour(getCronHour(mealSchedule.dinnerStartCron()))
+                .dinnerStartMinute(getCronMinute(mealSchedule.dinnerStartCron()))
+                .dinnerEndHour(getCronHour(mealSchedule.dinnerEndCron()))
+                .dinnerEndMinute(getCronMinute(mealSchedule.dinnerEndCron()))
+                .build();
+    }
+
+    // Cron 표현식에서 시간(hour) 추출
+    private String getCronHour(String cronExpression) {
+        return cronExpression.split(" ")[2];
+    }
+
+    // Cron 표현식에서 분(minute) 추출
+    private String getCronMinute(String cronExpression) {
+        return cronExpression.split(" ")[1];
+    }
+}

--- a/src/main/java/com/codenear/butterfly/product/application/ProductViewService.java
+++ b/src/main/java/com/codenear/butterfly/product/application/ProductViewService.java
@@ -2,14 +2,15 @@ package com.codenear.butterfly.product.application;
 
 import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
-import com.codenear.butterfly.member.domain.repository.member.MemberRepository;
 import com.codenear.butterfly.member.exception.MemberException;
 import com.codenear.butterfly.product.domain.Category;
 import com.codenear.butterfly.product.domain.ProductInventory;
+import com.codenear.butterfly.product.domain.SmallBusinessProduct;
 import com.codenear.butterfly.product.domain.dto.ProductDetailDTO;
 import com.codenear.butterfly.product.domain.dto.ProductViewDTO;
 import com.codenear.butterfly.product.domain.repository.FavoriteRepository;
 import com.codenear.butterfly.product.domain.repository.ProductInventoryRepository;
+import com.codenear.butterfly.product.domain.repository.ProductRedisRepository;
 import com.codenear.butterfly.product.util.ProductMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,11 +25,29 @@ public class ProductViewService {
 
     private final ProductInventoryRepository ProductInventoryRepository;
     private final FavoriteRepository favoriteRepository;
-    private final MemberRepository memberRepository;
+    private final ProductRedisRepository productRedisRepository;
+    private final ProductInventoryRepository productInventoryRepository;
 
     public List<ProductViewDTO> getAllProducts(MemberDTO member) {
         List<ProductInventory> products = ProductInventoryRepository.findAll();
         validateProducts(products);
+        return products.stream()
+                .sorted((p1, p2) -> Boolean.compare(p1.isSoldOut(), p2.isSoldOut()))
+                .map(product -> ProductMapper.toProductViewDTO(product, isProductFavorite(member, product.getId()), product.calculateGauge()))
+                .toList();
+    }
+
+    /**
+     * 소상공인 상품 리스트 반환 (점심 / 저녁)
+     * - 레디스에서 물품 ID 리스트를 가져와 반환
+     *
+     * @param member 사용자
+     * @return 상품 리스트
+     */
+    public List<ProductViewDTO> getSmallBusinessProducts(MemberDTO member) {
+        List<Long> productIds = productRedisRepository.loadSmallBusinessProductIds();
+        List<SmallBusinessProduct> products = productInventoryRepository.findByIdIn(productIds);
+
         return products.stream()
                 .sorted((p1, p2) -> Boolean.compare(p1.isSoldOut(), p2.isSoldOut()))
                 .map(product -> ProductMapper.toProductViewDTO(product, isProductFavorite(member, product.getId()), product.calculateGauge()))

--- a/src/main/java/com/codenear/butterfly/product/domain/SBMealType.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/SBMealType.java
@@ -1,0 +1,6 @@
+package com.codenear.butterfly.product.domain;
+
+public enum SBMealType {
+    LUNCH,
+    DINNER
+}

--- a/src/main/java/com/codenear/butterfly/product/domain/SmallBusinessProduct.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/SmallBusinessProduct.java
@@ -1,0 +1,38 @@
+package com.codenear.butterfly.product.domain;
+
+import com.codenear.butterfly.admin.products.dto.ProductCreateRequest;
+import com.codenear.butterfly.admin.products.dto.ProductUpdateRequest;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Entity
+@DiscriminatorValue("SMALL_BUSINESS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SmallBusinessProduct extends ProductInventory {
+    @Enumerated(EnumType.STRING)
+    private SBMealType orderType;
+
+    @Builder(builderMethodName = "createSBBuilder", buildMethodName = "buildCreateSB")
+    public SmallBusinessProduct(ProductCreateRequest request,
+                                String deliveryInformation,
+                                List<ProductImage> productImage,
+                                List<Keyword> keywords,
+                                List<ProductImage> descriptionImages) {
+        super(request, deliveryInformation, productImage, keywords, descriptionImages);
+        this.orderType = request.getOrderType();
+    }
+
+    @Override
+    public void update(ProductUpdateRequest request) {
+        super.update(request);
+    }
+}

--- a/src/main/java/com/codenear/butterfly/product/domain/SmallBusinessProduct.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/SmallBusinessProduct.java
@@ -19,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SmallBusinessProduct extends ProductInventory {
     @Enumerated(EnumType.STRING)
-    private SBMealType orderType;
+    private SBMealType mealType;
 
     @Builder(builderMethodName = "createSBBuilder", buildMethodName = "buildCreateSB")
     public SmallBusinessProduct(ProductCreateRequest request,
@@ -28,12 +28,12 @@ public class SmallBusinessProduct extends ProductInventory {
                                 List<Keyword> keywords,
                                 List<ProductImage> descriptionImages) {
         super(request, deliveryInformation, productImage, keywords, descriptionImages);
-        this.orderType = request.getOrderType();
+        this.mealType = request.getMealType();
     }
 
     @Override
     public void update(ProductUpdateRequest request) {
         super.update(request);
-        this.orderType = request.getMealType();
+        this.mealType = request.getMealType();
     }
 }

--- a/src/main/java/com/codenear/butterfly/product/domain/SmallBusinessProduct.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/SmallBusinessProduct.java
@@ -34,5 +34,6 @@ public class SmallBusinessProduct extends ProductInventory {
     @Override
     public void update(ProductUpdateRequest request) {
         super.update(request);
+        this.orderType = request.getMealType();
     }
 }

--- a/src/main/java/com/codenear/butterfly/product/domain/dto/MealScheduleTimeDTO.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/dto/MealScheduleTimeDTO.java
@@ -1,0 +1,14 @@
+package com.codenear.butterfly.product.domain.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MealScheduleTimeDTO(String lunchStartHour,
+                                  String lunchStartMinute,
+                                  String lunchEndHour,
+                                  String lunchEndMinute,
+                                  String dinnerStartHour,
+                                  String dinnerStartMinute,
+                                  String dinnerEndHour,
+                                  String dinnerEndMinute) {
+}

--- a/src/main/java/com/codenear/butterfly/product/domain/dto/MealSchedulerInfoDTO.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/dto/MealSchedulerInfoDTO.java
@@ -1,0 +1,14 @@
+package com.codenear.butterfly.product.domain.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MealSchedulerInfoDTO(String lunchStartCron,
+                                   String dinnerStartCron,
+                                   String lunchEndCron,
+                                   String dinnerEndCron,
+                                   boolean lunchStartSchedulerActive,
+                                   boolean dinnerStartSchedulerActive,
+                                   boolean lunchEndSchedulerActive,
+                                   boolean dinnerEndSchedulerActive) {
+}

--- a/src/main/java/com/codenear/butterfly/product/domain/repository/ProductInventoryRepository.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/repository/ProductInventoryRepository.java
@@ -3,6 +3,7 @@ package com.codenear.butterfly.product.domain.repository;
 import com.codenear.butterfly.product.domain.Category;
 import com.codenear.butterfly.product.domain.ProductInventory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,4 +17,7 @@ public interface ProductInventoryRepository extends JpaRepository<ProductInvento
     ProductInventory findProductByProductName(String productName);
 
     List<ProductInventory> findAllByProductNameIn(Set<String> productNames);
+
+    @Query(value = "select P.* from product P where P.product_type = :productType", nativeQuery = true)
+    List<ProductInventory> findByProductType(String productType);
 }

--- a/src/main/java/com/codenear/butterfly/product/domain/repository/ProductInventoryRepository.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/repository/ProductInventoryRepository.java
@@ -2,8 +2,11 @@ package com.codenear.butterfly.product.domain.repository;
 
 import com.codenear.butterfly.product.domain.Category;
 import com.codenear.butterfly.product.domain.ProductInventory;
+import com.codenear.butterfly.product.domain.SBMealType;
+import com.codenear.butterfly.product.domain.SmallBusinessProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,5 +22,10 @@ public interface ProductInventoryRepository extends JpaRepository<ProductInvento
     List<ProductInventory> findAllByProductNameIn(Set<String> productNames);
 
     @Query(value = "select P.* from product P where P.product_type = :productType", nativeQuery = true)
-    List<ProductInventory> findByProductType(String productType);
+    List<ProductInventory> findByProductType(@Param(value = "productType") String productType);
+
+    @Query(value = "SELECT SB.id from SmallBusinessProduct SB where SB.mealType = :mealType")
+    List<Long> findIdsByMealType(@Param(value = "mealType") SBMealType mealType);
+
+    List<SmallBusinessProduct> findByIdIn(List<Long> productIds);
 }

--- a/src/main/java/com/codenear/butterfly/product/domain/repository/ProductRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/repository/ProductRedisRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,17 +21,18 @@ public class ProductRedisRepository {
      * @param mealType 판매 시간 (LUNCH,DINNER)
      */
     public void saveCurrentSmallBusinessProductIds(SBMealType mealType) {
-        // TTL시간이 걸려있지만 최신화 예방 차원에서 이전 데이터 제거
-        redisTemplateByNumeric.delete(SMALL_BUSINESS_PRODUCT_IDS_KEY);
-
         List<Long> productIds = productService.loadSmallBusinessProductsByMealType(mealType);
         if (!productIds.isEmpty()) {
             // Redis List의 오른쪽(끝)에 모든 ID를 한 번에 추가
             redisTemplateByNumeric.opsForList().rightPushAll(SMALL_BUSINESS_PRODUCT_IDS_KEY, productIds);
-
-            // Redis List 키에 TTL 설정
-            redisTemplateByNumeric.expire(SMALL_BUSINESS_PRODUCT_IDS_KEY, 1000, TimeUnit.SECONDS);
         }
+    }
+
+    /**
+     * 소상공인 상품 캐시 삭제
+     */
+    public void clearCurrentSmallBusinessProductIds() {
+        redisTemplateByNumeric.delete(SMALL_BUSINESS_PRODUCT_IDS_KEY);
     }
 
     /**

--- a/src/main/java/com/codenear/butterfly/product/domain/repository/ProductRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/repository/ProductRedisRepository.java
@@ -1,0 +1,37 @@
+package com.codenear.butterfly.product.domain.repository;
+
+import com.codenear.butterfly.admin.products.application.AdminProductService;
+import com.codenear.butterfly.product.domain.SBMealType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRedisRepository {
+    private final String SMALL_BUSINESS_PRODUCT_IDS_KEY = "current_small_business_product_ids";
+    private final RedisTemplate<String, Long> redisTemplateByNumeric;
+    private final AdminProductService productService;
+
+    /**
+     * 시간대(mealType)에 맞는 상품 삽입 (갱신)
+     *
+     * @param mealType 판매 시간 (LUNCH,DINNER)
+     */
+    public void saveCurrentSmallBusinessProductIds(SBMealType mealType) {
+        // TTL시간이 걸려있지만 최신화 예방 차원에서 이전 데이터 제거
+        redisTemplateByNumeric.delete(SMALL_BUSINESS_PRODUCT_IDS_KEY);
+
+        List<Long> productIds = productService.loadSmallBusinessProductsByMealType(mealType);
+        if (!productIds.isEmpty()) {
+            // Redis List의 오른쪽(끝)에 모든 ID를 한 번에 추가
+            redisTemplateByNumeric.opsForList().rightPushAll(SMALL_BUSINESS_PRODUCT_IDS_KEY, productIds);
+
+            // Redis List 키에 TTL 설정
+            redisTemplateByNumeric.expire(SMALL_BUSINESS_PRODUCT_IDS_KEY, 1000, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/src/main/java/com/codenear/butterfly/product/domain/repository/ProductRedisRepository.java
+++ b/src/main/java/com/codenear/butterfly/product/domain/repository/ProductRedisRepository.java
@@ -34,4 +34,13 @@ public class ProductRedisRepository {
             redisTemplateByNumeric.expire(SMALL_BUSINESS_PRODUCT_IDS_KEY, 1000, TimeUnit.SECONDS);
         }
     }
+
+    /**
+     * 소상공인 상품 아이디 리스트 조회
+     *
+     * @return 아이디 리스트
+     */
+    public List<Long> loadSmallBusinessProductIds() {
+        return redisTemplateByNumeric.opsForList().range(SMALL_BUSINESS_PRODUCT_IDS_KEY, 0, -1);
+    }
 }

--- a/src/main/java/com/codenear/butterfly/product/presentation/ProductController.java
+++ b/src/main/java/com/codenear/butterfly/product/presentation/ProductController.java
@@ -5,6 +5,7 @@ import com.codenear.butterfly.global.util.ResponseUtil;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import com.codenear.butterfly.product.application.CategoryService;
 import com.codenear.butterfly.product.application.FavoriteService;
+import com.codenear.butterfly.product.application.MealScheduleService;
 import com.codenear.butterfly.product.application.ProductViewService;
 import com.codenear.butterfly.product.domain.dto.ProductViewDTO;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class ProductController implements ProductControllerSwagger {
     private final CategoryService categoryService;
     private final ProductViewService productViewService;
     private final FavoriteService favoriteService;
+    private final MealScheduleService mealScheduleService;
 
     @GetMapping("/categories")
     public ResponseEntity<ResponseDTO> categoryInfo() {
@@ -47,6 +49,11 @@ public class ProductController implements ProductControllerSwagger {
     @GetMapping("/sb")
     public ResponseEntity<ResponseDTO> getSmallBusinessProducts(@AuthenticationPrincipal MemberDTO memberDTO) {
         return ResponseUtil.createSuccessResponse(productViewService.getSmallBusinessProducts(memberDTO));
+    }
+
+    @GetMapping("/sb/meal-time")
+    public ResponseEntity<ResponseDTO> getMealTime(@AuthenticationPrincipal MemberDTO memberDTO) {
+        return ResponseUtil.createSuccessResponse(mealScheduleService.getMealScheduleTime());
     }
 
     @GetMapping("/{productId}")

--- a/src/main/java/com/codenear/butterfly/product/presentation/ProductController.java
+++ b/src/main/java/com/codenear/butterfly/product/presentation/ProductController.java
@@ -44,6 +44,11 @@ public class ProductController implements ProductControllerSwagger {
         }
     }
 
+    @GetMapping("/sb")
+    public ResponseEntity<ResponseDTO> getSmallBusinessProducts(@AuthenticationPrincipal MemberDTO memberDTO) {
+        return ResponseUtil.createSuccessResponse(productViewService.getSmallBusinessProducts(memberDTO));
+    }
+
     @GetMapping("/{productId}")
     public ResponseEntity<ResponseDTO> productDetail(@PathVariable(value = "productId") Long productId,
                                                      @AuthenticationPrincipal MemberDTO memberDTO) {

--- a/src/main/java/com/codenear/butterfly/product/presentation/ProductControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/product/presentation/ProductControllerSwagger.java
@@ -44,6 +44,14 @@ public interface ProductControllerSwagger {
     })
     ResponseEntity<ResponseDTO> getSmallBusinessProducts(@AuthenticationPrincipal MemberDTO memberDTO);
 
+    @Operation(summary = "소상공인 상품 판매 시간", description = "점심/저녁 판매 시간 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "body", description = "응답 메시지 예시",
+                    content = @Content(schema = @Schema(implementation = ProductViewDTO.class))),
+            @ApiResponse(responseCode = "200", description = "Success")
+    })
+    ResponseEntity<ResponseDTO> getMealTime(@AuthenticationPrincipal MemberDTO memberDTO);
+
     @Operation(summary = "상품 상세 정보", description = "상품 상세 정보 API")
     @ApiResponses({
             @ApiResponse(responseCode = "body", description = "응답 메시지 예시",

--- a/src/main/java/com/codenear/butterfly/product/presentation/ProductControllerSwagger.java
+++ b/src/main/java/com/codenear/butterfly/product/presentation/ProductControllerSwagger.java
@@ -1,7 +1,6 @@
 package com.codenear.butterfly.product.presentation;
 
 import com.codenear.butterfly.global.dto.ResponseDTO;
-import com.codenear.butterfly.member.domain.Member;
 import com.codenear.butterfly.member.domain.dto.MemberDTO;
 import com.codenear.butterfly.product.domain.Category;
 import com.codenear.butterfly.product.domain.dto.ProductDetailDTO;
@@ -37,6 +36,14 @@ public interface ProductControllerSwagger {
     ResponseEntity<ResponseDTO> productInfoByCategory(@RequestParam("category") String category,
                                                       @AuthenticationPrincipal MemberDTO memberDTO);
 
+    @Operation(summary = "소상공인 상품 리스트 (점심/저녁)", description = "점심/저녁 시간대에 따른 소상공인 물품 리스트 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "body", description = "응답 메시지 예시",
+                    content = @Content(schema = @Schema(implementation = ProductViewDTO.class))),
+            @ApiResponse(responseCode = "200", description = "Success")
+    })
+    ResponseEntity<ResponseDTO> getSmallBusinessProducts(@AuthenticationPrincipal MemberDTO memberDTO);
+
     @Operation(summary = "상품 상세 정보", description = "상품 상세 정보 API")
     @ApiResponses({
             @ApiResponse(responseCode = "body", description = "응답 메시지 예시",
@@ -67,12 +74,12 @@ public interface ProductControllerSwagger {
             @ApiResponse(responseCode = "409", description = "Conflict (Duplicate)")
     })
     ResponseEntity<ResponseDTO> addFavorite(@PathVariable(value = "productId") Long productId,
-                                                   @AuthenticationPrincipal MemberDTO memberDTO);
+                                            @AuthenticationPrincipal MemberDTO memberDTO);
 
     @Operation(summary = "찜 목록 삭제", description = "찜 목록 삭제 Api")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Success"),
     })
     ResponseEntity<ResponseDTO> removeFavorite(@PathVariable(value = "productId") Long productId,
-                                            @AuthenticationPrincipal MemberDTO memberDTO);
+                                               @AuthenticationPrincipal MemberDTO memberDTO);
 }

--- a/src/main/java/com/codenear/butterfly/product/util/SBProductScheduler.java
+++ b/src/main/java/com/codenear/butterfly/product/util/SBProductScheduler.java
@@ -1,31 +1,209 @@
 package com.codenear.butterfly.product.util;
 
+import com.codenear.butterfly.admin.products.dto.ScheduleUpdateRequest;
 import com.codenear.butterfly.product.domain.SBMealType;
+import com.codenear.butterfly.product.domain.dto.MealSchedulerInfoDTO;
 import com.codenear.butterfly.product.domain.repository.ProductRedisRepository;
-import lombok.RequiredArgsConstructor;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalTime;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class SBProductScheduler {
+    // 기본 cron 표현식 (초기값)
+    private static final String LUNCH_START_KEY = "lunchStart";
+    private static final String LUNCH_END_KEY = "lunchEnd";
+    private static final String DINNER_START_KEY = "dinnerStart";
+    private static final String DINNER_END_KEY = "dinnerEnd";
     private final ProductRedisRepository productRedisRepository;
+    private final TaskScheduler taskScheduler;
+    private final Map<String, ScheduledFuture<?>> scheduledTasks = new HashMap<>();
+    private final Map<String, String> cronExpressions = new HashMap<>();
 
-    // 매일 자정 (00:00)에 '점심' 상품을 'current_small_business_products' Redis Hash Key에 캐싱
-    @Scheduled(cron = "*/8 * * * * *")
-    public void updateToLunchProducts() {
-        log.info("공통 캐시에 점심 상품 업데이트 스케줄러 실행: {}", LocalTime.now());
-        productRedisRepository.saveCurrentSmallBusinessProductIds(SBMealType.LUNCH);
+    @Autowired
+    public SBProductScheduler(ProductRedisRepository productRedisRepository) {
+        this.productRedisRepository = productRedisRepository;
+        this.taskScheduler = createDedicatedTaskScheduler();
+        // 기본값 초기화
+        cronExpressions.put(LUNCH_START_KEY, "0 0 0 * * *"); // 점심 시작 (00:00)
+        cronExpressions.put(LUNCH_END_KEY, "0 30 11 * * *"); // 점심 종료 (11:30)
+        cronExpressions.put(DINNER_START_KEY, "0 30 12 * * *"); // 저녁 시작 (12:30)
+        cronExpressions.put(DINNER_END_KEY, "0 30 17 * * *"); // 저녁 종료 (17:30)
     }
 
-    // 매일 12시 30분 (12:30)에 '저녁' 상품을 Redis Hash Key에 캐싱
-    @Scheduled(cron = "*/13 * * * * *")
-    public void updateToDinnerProducts() {
-        log.info("공통 캐시에 저녁 상품 업데이트 스케줄러 실행: {}", LocalTime.now());
-        productRedisRepository.saveCurrentSmallBusinessProductIds(SBMealType.DINNER);
+    @PostConstruct
+    public void initializeSchedulers() {
+        log.info("동적 스케줄러 초기화 시작");
+        startScheduler(LUNCH_START_KEY, () -> updateProducts(SBMealType.LUNCH), cronExpressions.get(LUNCH_START_KEY));
+        startScheduler(LUNCH_END_KEY, () -> clearProducts(SBMealType.LUNCH), cronExpressions.get(LUNCH_END_KEY));
+        startScheduler(DINNER_START_KEY, () -> updateProducts(SBMealType.DINNER), cronExpressions.get(DINNER_START_KEY));
+        startScheduler(DINNER_END_KEY, () -> clearProducts(SBMealType.DINNER), cronExpressions.get(DINNER_END_KEY));
+    }
+
+    @PreDestroy
+    public void destroySchedulers() {
+        log.info("스케줄러 종료 중...");
+        stopScheduler(LUNCH_START_KEY);
+        stopScheduler(LUNCH_END_KEY);
+        stopScheduler(DINNER_START_KEY);
+        stopScheduler(DINNER_END_KEY);
+        if (taskScheduler instanceof ThreadPoolTaskScheduler) {
+            ((ThreadPoolTaskScheduler) taskScheduler).shutdown();
+        }
+    }
+
+    /**
+     * 점심 스케줄 동적 변경
+     *
+     * @param request 변경 시간을 담은 DTO (cron)
+     */
+    public void updateLunchSchedule(ScheduleUpdateRequest request) {
+        updateSchedule(request, "점심", LUNCH_START_KEY, LUNCH_END_KEY,
+                () -> updateProducts(SBMealType.LUNCH), () -> clearProducts(SBMealType.LUNCH));
+    }
+
+    /**
+     * 저녁 스케줄 동적 변경
+     *
+     * @param request 변경 시간을 담은 DTO (cron)
+     */
+    public void updateDinnerSchedule(ScheduleUpdateRequest request) {
+        updateSchedule(request, "저녁", DINNER_START_KEY, DINNER_END_KEY,
+                () -> updateProducts(SBMealType.DINNER), () -> clearProducts(SBMealType.DINNER));
+    }
+
+    /**
+     * 현재 스케줄 정보 조회
+     */
+    public MealSchedulerInfoDTO getCurrentScheduleInfo() {
+        return MealSchedulerInfoDTO.builder()
+                .lunchStartCron(cronExpressions.get(LUNCH_START_KEY))
+                .lunchEndCron(cronExpressions.get(LUNCH_END_KEY))
+                .dinnerStartCron(cronExpressions.get(DINNER_START_KEY))
+                .dinnerEndCron(cronExpressions.get(DINNER_END_KEY))
+                .lunchStartSchedulerActive(isSchedulerActive(LUNCH_START_KEY))
+                .lunchEndSchedulerActive(isSchedulerActive(LUNCH_END_KEY))
+                .dinnerStartSchedulerActive(isSchedulerActive(DINNER_START_KEY))
+                .dinnerEndSchedulerActive(isSchedulerActive(DINNER_END_KEY))
+                .build();
+    }
+
+    /**
+     * 공통 스케줄 업데이트 로직
+     */
+    private void updateSchedule(ScheduleUpdateRequest request, String mealType,
+                                String startKey, String endKey,
+                                Runnable startTask, Runnable endTask) {
+        try {
+            // Cron 표현식 유효성 검증
+            new CronTrigger(request.cronStartExpression());
+            new CronTrigger(request.cronEndExpression());
+
+            // 시간 순서 검증
+            validateScheduleTimes(request, mealType);
+
+            // 스케줄 업데이트
+            cronExpressions.put(startKey, request.cronStartExpression());
+            cronExpressions.put(endKey, request.cronEndExpression());
+            startScheduler(startKey, startTask, cronExpressions.get(startKey));
+            startScheduler(endKey, endTask, cronExpressions.get(endKey));
+
+            log.info("{} 스케줄 업데이트 완료: start={}, end={}", mealType,
+                    cronExpressions.get(startKey), cronExpressions.get(endKey));
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 {} cron 표현식: {}", mealType, e.getMessage());
+            throw new IllegalArgumentException("잘못된 cron 표현식입니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 스케줄러 순서 검증: 시작 시간이 종료 시간보다 빠르도록
+     */
+    private void validateScheduleTimes(ScheduleUpdateRequest request, String mealType) {
+        int startHour = Integer.parseInt(request.cronStartExpression().split(" ")[2]);
+        int startMinute = Integer.parseInt(request.cronStartExpression().split(" ")[1]);
+        int endHour = Integer.parseInt(request.cronEndExpression().split(" ")[2]);
+        int endMinute = Integer.parseInt(request.cronEndExpression().split(" ")[1]);
+
+        if (startHour > endHour || (startHour == endHour && startMinute >= endMinute)) {
+            throw new IllegalArgumentException(mealType + " 시작 시간은 종료 시간보다 빠르거나 같을 수 없습니다.");
+        }
+    }
+
+    /**
+     * SBProductScheduler 전용 TaskScheduler
+     */
+    private TaskScheduler createDedicatedTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4); // 점심 시작/종료, 저녁 시작/종료
+        scheduler.setThreadNamePrefix("sb-product-scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(20);
+        scheduler.initialize();
+        return scheduler;
+    }
+
+    /**
+     * 공통 스케줄러 시작
+     */
+    private void startScheduler(String taskKey, Runnable task, String cronExpression) {
+        stopScheduler(taskKey); // 기존 스케줄러 중지
+        ScheduledFuture<?> scheduledTask = taskScheduler.schedule(task, new CronTrigger(cronExpression));
+        scheduledTasks.put(taskKey, scheduledTask);
+        log.info("{} 스케줄러 시작 - cron: {}", taskKey, cronExpression);
+    }
+
+    /**
+     * 공통 스케줄러 중지
+     */
+    private void stopScheduler(String taskKey) {
+        ScheduledFuture<?> scheduledTask = scheduledTasks.get(taskKey);
+        if (scheduledTask != null && !scheduledTask.isCancelled()) {
+            scheduledTask.cancel(false);
+            log.info("{} 스케줄러 중지됨", taskKey);
+        }
+    }
+
+    /**
+     * 스케줄러 활성 상태 확인
+     */
+    private boolean isSchedulerActive(String taskKey) {
+        ScheduledFuture<?> task = scheduledTasks.get(taskKey);
+        return task != null && !task.isCancelled();
+    }
+
+    /**
+     * 상품 업데이트
+     */
+    private void updateProducts(SBMealType mealType) {
+        try {
+            log.info("{} 상품 업데이트 스케줄러 실행: {}", mealType.name(), LocalDate.now());
+            productRedisRepository.saveCurrentSmallBusinessProductIds(mealType);
+        } catch (Exception e) {
+            log.error("{} 상품 업데이트 중 오류 발생", mealType.name(), e);
+        }
+    }
+
+    /**
+     * 상품 캐시 삭제
+     */
+    private void clearProducts(SBMealType mealType) {
+        try {
+            log.info("{} 상품 삭제 스케줄러 실행: {}", mealType.name(), LocalDate.now());
+            productRedisRepository.clearCurrentSmallBusinessProductIds();
+        } catch (Exception e) {
+            log.error("{} 상품 캐시 삭제 중 오류 발생", mealType.name(), e);
+        }
     }
 }

--- a/src/main/java/com/codenear/butterfly/product/util/SBProductScheduler.java
+++ b/src/main/java/com/codenear/butterfly/product/util/SBProductScheduler.java
@@ -1,0 +1,31 @@
+package com.codenear.butterfly.product.util;
+
+import com.codenear.butterfly.product.domain.SBMealType;
+import com.codenear.butterfly.product.domain.repository.ProductRedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SBProductScheduler {
+    private final ProductRedisRepository productRedisRepository;
+
+    // 매일 자정 (00:00)에 '점심' 상품을 'current_small_business_products' Redis Hash Key에 캐싱
+    @Scheduled(cron = "*/8 * * * * *")
+    public void updateToLunchProducts() {
+        log.info("공통 캐시에 점심 상품 업데이트 스케줄러 실행: {}", LocalTime.now());
+        productRedisRepository.saveCurrentSmallBusinessProductIds(SBMealType.LUNCH);
+    }
+
+    // 매일 12시 30분 (12:30)에 '저녁' 상품을 Redis Hash Key에 캐싱
+    @Scheduled(cron = "*/13 * * * * *")
+    public void updateToDinnerProducts() {
+        log.info("공통 캐시에 저녁 상품 업데이트 스케줄러 실행: {}", LocalTime.now());
+        productRedisRepository.saveCurrentSmallBusinessProductIds(SBMealType.DINNER);
+    }
+}

--- a/src/main/resources/templates/admin/products/product-create.html
+++ b/src/main/resources/templates/admin/products/product-create.html
@@ -34,7 +34,7 @@
 
                             <div class="form-group hidden-field" id="mealTypeGroup">
                                 <label>식사 타입</label>
-                                <select class="form-control" name="orderType">
+                                <select class="form-control" name="mealType">
                                     <option value="">식사 타입을 선택하세요</option>
                                     <option value="LUNCH">점심</option>
                                     <option value="DINNER">저녁</option>
@@ -154,9 +154,9 @@
     // DOM 요소 캐싱
     const productTypeSelect = document.getElementById("productType");
     const mealTypeGroup = document.getElementById("mealTypeGroup");
-    const mealTypeSelect = mealTypeGroup.querySelector('select[name="orderType"]'); // mealType select 요소
+    const mealTypeSelect = mealTypeGroup.querySelector('select[name="mealType"]'); // mealType select 요소
 
-    // 초기 상태 설정: OrderType 필드 숨김
+    // 초기 상태 설정: mealType 필드 숨김
     mealTypeGroup.classList.add("hidden-field");
 
     // 상품 타입 변경 이벤트 리스너

--- a/src/main/resources/templates/admin/products/product-create.html
+++ b/src/main/resources/templates/admin/products/product-create.html
@@ -24,6 +24,24 @@
                     <div class="card-body">
                         <form th:action="@{/admin/products/new}" method="post" enctype="multipart/form-data">
                             <div class="form-group">
+                                <label>상품 타입</label>
+                                <select class="form-control" id="productType" name="productType" required>
+                                    <option value="">상품 타입을 선택하세요</option>
+                                    <option value="INVENTORY">일반 상품</option>
+                                    <option value="SMALL_BUSINESS">소상공인 상품</option>
+                                </select>
+                            </div>
+
+                            <div class="form-group hidden-field" id="mealTypeGroup">
+                                <label>식사 타입</label>
+                                <select class="form-control" name="orderType">
+                                    <option value="">식사 타입을 선택하세요</option>
+                                    <option value="LUNCH">점심</option>
+                                    <option value="DINNER">저녁</option>
+                                </select>
+                            </div>
+
+                            <div class="form-group">
                                 <label>상품 이미지</label>
                                 <input type="file" class="form-control-file" name="productImage" accept="image/*" multiple>
                             </div>
@@ -133,14 +151,38 @@
 <script th:inline="javascript">
     let idx = 0;
 
+    // DOM 요소 캐싱
+    const productTypeSelect = document.getElementById("productType");
+    const mealTypeGroup = document.getElementById("mealTypeGroup");
+    const mealTypeSelect = mealTypeGroup.querySelector('select[name="orderType"]'); // mealType select 요소
+
+    // 초기 상태 설정: OrderType 필드 숨김
+    mealTypeGroup.classList.add("hidden-field");
+
+    // 상품 타입 변경 이벤트 리스너
+    productTypeSelect.addEventListener("change", function () {
+        const selectedType = this.value;
+
+        if (selectedType === "SMALL_BUSINESS") {
+            // 소상공인 상품 선택 시 MealType 필드 표시
+            mealTypeGroup.classList.remove("hidden-field");
+            mealTypeSelect.setAttribute('required', 'required'); // MealType을 필수로 만듦
+        } else {
+            // 다른 상품 타입 선택 시 MealType 필드 숨김
+            mealTypeGroup.classList.add("hidden-field");
+            mealTypeSelect.removeAttribute('required'); // 필수 속성 제거
+            mealTypeSelect.value = ""; // 값 초기화
+        }
+    });
+
     // 구간 할인율 추가
     document.getElementById("addDiscountRate").addEventListener("click", function () {
         const container = document.getElementById("discountRateContainer");
 
         const row = document.createElement("div");
+        row.className = "discount-rate-row mb-3"; // 클래스 추가
 
         row.innerHTML = `
-            <div class="discount-rate-row mb-3">
             <div class="form-row">
                 <div class="form-group col-md-3">
                     <label>최소 참여율 (%)</label>
@@ -155,17 +197,16 @@
                     <input type="number" step="0.1" class="form-control" name="discountRates[${idx}].discountRate" required>
                 </div>
                 <div class="form-group col-md-3 d-flex align-items-end">
-                    <button type="button" class="btn btn-danger btn-sm remove-rate" data-is-new="true">삭제</button>
+                    <button type="button" class="btn btn-danger btn-sm remove-rate">삭제</button>
                 </div>
             </div>
-        </div>
         `;
 
         container.appendChild(row);
         idx++;
     });
 
-    // 구간 할인율 삭제
+    // 구간 할인율 삭제 (이벤트 위임 사용)
     document.addEventListener("click", function (e) {
         if (e.target.classList.contains("remove-rate")) {
             const row = e.target.closest(".discount-rate-row");
@@ -176,23 +217,17 @@
         }
     });
 
-    // 구간 할인율 삭제 시 재정렬
+    // 구간 할인율 삭제 시 재정렬 함수
     function updateDiscountRateIndexes() {
         const rows = document.querySelectorAll(".discount-rate-row");
         rows.forEach((row, newIdx) => {
             const inputs = row.querySelectorAll("input");
             inputs.forEach(input => {
-                if (input.name.includes("minParticipationRate")) {
-                    input.name = `discountRates[${newIdx}].minParticipationRate`;
-                } else if (input.name.includes("maxParticipationRate")) {
-                    input.name = `discountRates[${newIdx}].maxParticipationRate`;
-                } else if (input.name.includes("discountRate")) {
-                    input.name = `discountRates[${newIdx}].discountRate`;
-                }
+                // name 속성에서 현재 인덱스 부분을 새 인덱스로 교체
+                input.name = input.name.replace(/\[\d+\]/, `[${newIdx}]`);
             });
         });
-
-        idx = rows.length;
+        idx = rows.length; // 현재 존재하는 행의 개수로 idx 업데이트
     }
 </script>
 </html>

--- a/src/main/resources/templates/admin/products/product-edit.html
+++ b/src/main/resources/templates/admin/products/product-edit.html
@@ -9,6 +9,12 @@
     <link th:href="@{/sb-admin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
     <link th:href="@{/sb-admin/css/sb-admin-2.min.css}" rel="stylesheet">
+    <style>
+        /* 숨김 처리될 요소에 적용할 스타일 */
+        .hidden-field {
+            display: none;
+        }
+    </style>
 </head>
 
 <body id="page-top">
@@ -25,6 +31,14 @@
                         <form th:action="@{/admin/products/{id}/edit(id=${product.id})}" method="post" enctype="multipart/form-data">
                             <input type="hidden" name="_method" value="PUT" />
                             <input type="hidden" name="id" th:value="${product.id}" />
+                            <input type="hidden" name="productType" th:value="${productType}" id="productTypeHidden"> <div class="form-group" id="mealTypeGroup">
+                            <label>식사 타입</label>
+                            <select class="form-control" name="mealType">
+                                <option value="">식사 타입을 선택하세요</option>
+                                <option value="LUNCH" th:selected="${mealType != null and mealType.name() == 'LUNCH'}">점심</option>
+                                <option value="DINNER" th:selected="${mealType != null and mealType.name() == 'DINNER'}">저녁</option>
+                            </select>
+                        </div>
 
                             <div class="form-group" >
                                 <label>현재 상품 이미지</label>
@@ -174,6 +188,22 @@
 <th:block th:replace="~{fragments/scripts :: body}"></th:block>
 </body>
 <script th:inline="javascript">
+    // 상품 타입에 따라 MealType 필드 가시성 제어
+    document.addEventListener('DOMContentLoaded', function() {
+        const productType = /*[[${productType}]]*/ 'INVENTORY'; // 컨트롤러에서 받은 productType 값
+        const mealTypeGroup = document.getElementById('mealTypeGroup');
+        const mealTypeSelect = mealTypeGroup.querySelector('select[name="mealType"]');
+
+        if (productType === 'SMALL_BUSINESS') {
+            mealTypeGroup.classList.remove('hidden-field');
+            mealTypeSelect.setAttribute('required', 'required');
+        } else {
+            mealTypeGroup.classList.add('hidden-field');
+            mealTypeSelect.removeAttribute('required');
+        }
+    });
+
+    // 기존 할인율 구간 추가/삭제 로직 (변화 없음)
     function getProductIdFromUrl() {
         const pathSegments = window.location.pathname.split('/');
         const productIdIndex = pathSegments.indexOf('products') + 1;

--- a/src/main/resources/templates/admin/products/product-list.html
+++ b/src/main/resources/templates/admin/products/product-list.html
@@ -27,7 +27,16 @@
                 <div class="card shadow mb-4">
                     <div class="card-header py-3 d-flex justify-content-between align-items-center">
                         <h6 class="m-0 font-weight-bold text-primary">상품 목록</h6>
-                        <div class="d-flex">
+                        <div class="d-flex align-items-center">
+                            <div class="form-group mb-0 mr-3">
+                                <label for="productTypeFilter" class="sr-only">상품 타입 필터</label>
+                                <select class="form-control" id="productTypeFilter" onchange="filterProducts()">
+                                    <option value="ALL" th:selected="${selectedType == null or selectedType == 'ALL'}">전체</option>
+                                    <option value="INVENTORY" th:selected="${selectedType == 'INVENTORY'}">일반 상품</option>
+                                    <option value="SMALL_BUSINESS" th:selected="${selectedType == 'SMALL_BUSINESS'}">소상공인 상품</option>
+                                </select>
+                            </div>
+
                             <a th:href="@{/admin/products/new}" class="btn btn-primary">상품 추가</a>
 
                             <form th:action="@{/admin/products/push}" method="post" style="display: inline;"
@@ -42,7 +51,7 @@
                                 <thead>
                                 <tr>
                                     <th>ID</th>
-                                    <th>상품명</th>
+                                    <th>상품 타입</th> <th>상품명</th>
                                     <th>회사명</th>
                                     <th>카테고리</th>
                                     <th>원가</th>
@@ -55,9 +64,13 @@
                                 <tbody>
                                 <tr th:each="product : ${products}">
                                     <td th:text="${product.id}">1</td>
+                                    <td>
+                                        <span th:if="${product instanceof T(com.codenear.butterfly.product.domain.SmallBusinessProduct)}">소상공인</span>
+                                        <span th:unless="${product instanceof T(com.codenear.butterfly.product.domain.SmallBusinessProduct)}">일반 상품</span>
+                                    </td>
                                     <td th:text="${product.productName}">상품명</td>
                                     <td th:text="${product.companyName}">회사명</td>
-                                    <td th:text="${product.category.value}">카테고리</td>
+                                    <td th:text="${product.category?.value}">카테고리</td>
                                     <td th:text="${#numbers.formatDecimal(product.originalPrice, 0, 'COMMA', 0, 'POINT')}">10000</td>
                                     <td th:text="${#numbers.formatDecimal(product.saleRate, 1, 'COMMA', 1, 'POINT')} + '%'">10.0</td>
                                     <td th:text="${product.stockQuantity}">100</td>
@@ -77,6 +90,8 @@
                                         </form>
                                     </td>
                                 </tr>
+                                <tr th:if="${#lists.isEmpty(products)}">
+                                    <td colspan="10" class="text-center">상품이 없습니다.</td> </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -88,5 +103,19 @@
 </div>
 
 <th:block th:replace="~{fragments/scripts :: body}"></th:block>
+
+<script>
+    // 상품 타입 필터
+    function filterProducts() {
+        const selectElement = document.getElementById('productTypeFilter');
+        const selectedValue = selectElement.value;
+        let url = '/admin/products'; // 기본 URL
+
+        if (selectedValue && selectedValue !== 'ALL') {
+            url += '?type=' + selectedValue; // 'ALL'이 아니면 type 파라미터 추가
+        }
+        window.location.href = url; // 새로운 URL로 이동하여 페이지 재로드
+    }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/adminDashboard.html
+++ b/src/main/resources/templates/adminDashboard.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>CODE NEAR</title>
+    <title>CODE NEAR - 대시보드</title>
 
     <!-- 템플릿용 사용자 정의 폰트 -->
     <link th:href="@{/sb-admin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
@@ -33,30 +33,328 @@
             <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
                 <!-- 사이드바 토글 (상단바) -->
                 <button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3">
-                    <i className='fa fa-bars'></i>
+                    <i class="fa fa-bars"></i>
                 </button>
             </nav>
 
             <!-- 페이지 콘텐츠 시작 -->
-            <div className='container-fluid'>
+            <div class="container-fluid">
 
                 <!-- 페이지 제목 -->
-                <h1 className='h3 mb-4 text-gray-800'>대시보드</h1>
+                <div class="d-sm-flex align-items-center justify-content-between mb-4">
+                    <h1 class="h3 mb-0 text-gray-800">
+                        <i class="fas fa-tachometer-alt mr-2"></i>대시보드
+                    </h1>
+                </div>
 
-                <!-- 대시보드 콘텐츠 위치 -->
+                <!-- 알림 메시지 -->
+                <div th:if="${message}" th:class="|alert alert-${messageType} alert-dismissible fade show|" role="alert">
+                    <span th:text="${message}"></span>
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">×</span>
+                    </button>
+                </div>
+
+                <!-- 스케줄 관리 섹션 -->
+                <div class="row">
+                    <!-- 점심 스케줄 카드 -->
+                    <div class="col-xl-6 col-md-6 mb-4">
+                        <div class="card schedule-card lunch-card shadow">
+                            <div class="card-body">
+                                <div class="text-center">
+                                    <div class="meal-icon">
+                                        <i class="fas fa-sun"></i>
+                                    </div>
+                                    <h5 class="card-title mb-3">소상공인 점심 스케줄</h5>
+
+                                    <div class="schedule-status">
+                                        <div class="current-time" th:if="${scheduleInfo != null and scheduleInfo.lunchStartCron != null}">
+                                            시작 시간: <span th:text="${#strings.arraySplit(scheduleInfo.lunchStartCron, ' ')[2] + ':' + #strings.arraySplit(scheduleInfo.lunchStartCron, ' ')[1]}">12:00</span>
+                                        </div>
+                                        <div class="current-time" th:if="${scheduleInfo != null and scheduleInfo.lunchEndCron != null}">
+                                            종료 시간: <span th:text="${#strings.arraySplit(scheduleInfo.lunchEndCron, ' ')[2] + ':' + #strings.arraySplit(scheduleInfo.lunchEndCron, ' ')[1]}">14:00</span>
+                                        </div>
+                                        <div class="current-time" th:unless="${scheduleInfo != null and scheduleInfo.lunchStartCron != null}">
+                                            설정되지 않음
+                                        </div>
+                                    </div>
+
+                                    <form th:action="@{/admin/schedule/lunch}" method="post" class="mt-4" onsubmit="prepareCronExpressions(event, 'lunch')">
+                                        <input type="hidden" name="cronStartExpression" id="lunchStartCron">
+                                        <input type="hidden" name="cronEndExpression" id="lunchEndCron">
+                                        <div class="row justify-content-center">
+                                            <div class="col-md-6">
+                                                <label class="text-dark">시작 시간</label>
+                                                <div class="row justify-content-center">
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="lunchStartHour" name="lunchStartHour"
+                                                               min="0" max="23" placeholder="시"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.lunchStartCron != null} ? ${#strings.arraySplit(scheduleInfo.lunchStartCron, ' ')[2]} : ''"
+                                                               required>
+                                                    </div>
+                                                    <div class="col-auto align-self-center">
+                                                        <span class="h5">:</span>
+                                                    </div>
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="lunchStartMinute" name="lunchStartMinute"
+                                                               min="0" max="59" placeholder="분"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.lunchStartCron != null} ? ${#strings.arraySplit(scheduleInfo.lunchStartCron, ' ')[1]} : ''"
+                                                               required>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label class="text-dark">종료 시간</label>
+                                                <div class="row justify-content-center">
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="lunchEndHour" name="lunchEndHour"
+                                                               min="0" max="23" placeholder="시"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.lunchEndCron != null} ? ${#strings.arraySplit(scheduleInfo.lunchEndCron, ' ')[2]} : ''"
+                                                               required>
+                                                    </div>
+                                                    <div class="col-auto align-self-center">
+                                                        <span class="h5">:</span>
+                                                    </div>
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="lunchEndMinute" name="lunchEndMinute"
+                                                               min="0" max="59" placeholder="분"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.lunchEndCron != null} ? ${#strings.arraySplit(scheduleInfo.lunchEndCron, ' ')[1]} : ''"
+                                                               required>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <button type="submit" class="btn btn-update text-white mt-3">
+                                            <i class="fas fa-clock mr-2"></i>점심 스케줄 저장
+                                        </button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 저녁 스케줄 카드 -->
+                    <div class="col-xl-6 col-md-6 mb-4">
+                        <div class="card schedule-card dinner-card shadow">
+                            <div class="card-body">
+                                <div class="text-center">
+                                    <div class="meal-icon">
+                                        <i class="fas fa-moon"></i>
+                                    </div>
+                                    <h5 class="card-title mb-3">소상공인 저녁 스케줄</h5>
+
+                                    <div class="schedule-status">
+                                        <div class="current-time" th:if="${scheduleInfo != null and scheduleInfo.dinnerStartCron != null}">
+                                            시작 시간: <span th:text="${#strings.arraySplit(scheduleInfo.dinnerStartCron, ' ')[2] + ':' + #strings.arraySplit(scheduleInfo.dinnerStartCron, ' ')[1]}">18:00</span>
+                                        </div>
+                                        <div class="current-time" th:if="${scheduleInfo != null and scheduleInfo.dinnerEndCron != null}">
+                                            종료 시간: <span th:text="${#strings.arraySplit(scheduleInfo.dinnerEndCron, ' ')[2] + ':' + #strings.arraySplit(scheduleInfo.dinnerEndCron, ' ')[1]}">20:00</span>
+                                        </div>
+                                        <div class="current-time" th:unless="${scheduleInfo != null and scheduleInfo.dinnerStartCron != null}">
+                                            설정되지 않음
+                                        </div>
+                                    </div>
+
+                                    <form th:action="@{/admin/schedule/dinner}" method="post" class="mt-4" onsubmit="prepareCronExpressions(event, 'dinner')">
+                                        <input type="hidden" name="cronStartExpression" id="dinnerStartCron">
+                                        <input type="hidden" name="cronEndExpression" id="dinnerEndCron">
+                                        <div class="row justify-content-center">
+                                            <div class="col-md-6">
+                                                <label class="text-dark">시작 시간</label>
+                                                <div class="row justify-content-center">
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="dinnerStartHour" name="dinnerStartHour"
+                                                               min="0" max="23" placeholder="시"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.dinnerStartCron != null} ? ${#strings.arraySplit(scheduleInfo.dinnerStartCron, ' ')[2]} : ''"
+                                                               required>
+                                                    </div>
+                                                    <div class="col-auto align-self-center">
+                                                        <span class="h5">:</span>
+                                                    </div>
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="dinnerStartMinute" name="dinnerStartMinute"
+                                                               min="0" max="59" placeholder="분"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.dinnerStartCron != null} ? ${#strings.arraySplit(scheduleInfo.dinnerStartCron, ' ')[1]} : ''"
+                                                               required>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label class="text-dark">종료 시간</label>
+                                                <div class="row justify-content-center">
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="dinnerEndHour" name="dinnerEndHour"
+                                                               min="0" max="23" placeholder="시"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.dinnerEndCron != null} ? ${#strings.arraySplit(scheduleInfo.dinnerEndCron, ' ')[2]} : ''"
+                                                               required>
+                                                    </div>
+                                                    <div class="col-auto align-self-center">
+                                                        <span class="h5">:</span>
+                                                    </div>
+                                                    <div class="col-auto">
+                                                        <input type="number" class="form-control time-input"
+                                                               id="dinnerEndMinute" name="dinnerEndMinute"
+                                                               min="0" max="59" placeholder="분"
+                                                               th:value="${scheduleInfo != null and scheduleInfo.dinnerEndCron != null} ? ${#strings.arraySplit(scheduleInfo.dinnerEndCron, ' ')[1]} : ''"
+                                                               required>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <button type="submit" class="btn btn-update text-white mt-3">
+                                            <i class="fas fa-clock mr-2"></i>저녁 스케줄 저장
+                                        </button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 스케줄러 상태 정보 -->
+                <div class="row" th:if="${scheduleInfo != null}">
+                    <div class="col-12">
+                        <div class="card shadow mb-4">
+                            <div class="card-header py-3">
+                                <h6 class="m-0 font-weight-bold text-primary">
+                                    <i class="fas fa-info-circle mr-2"></i>스케줄러 상태
+                                </h6>
+                            </div>
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <p><strong>점심 시작 스케줄 상태:</strong>
+                                            <span th:if="${scheduleInfo.lunchStartSchedulerActive}" class="text-success">
+                                                <i class="fas fa-check-circle mr-1"></i>활성
+                                            </span>
+                                            <span th:unless="${scheduleInfo.lunchStartSchedulerActive}" class="text-danger">
+                                                <i class="fas fa-times-circle mr-1"></i>비활성
+                                            </span>
+                                        </p>
+                                        <p><strong>점심 종료 스케줄 상태:</strong>
+                                            <span th:if="${scheduleInfo.lunchEndSchedulerActive}" class="text-success">
+                                                <i class="fas fa-check-circle mr-1"></i>활성
+                                            </span>
+                                            <span th:unless="${scheduleInfo.lunchEndSchedulerActive}" class="text-danger">
+                                                <i class="fas fa-times-circle mr-1"></i>비활성
+                                            </span>
+                                        </p>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <p><strong>저녁 시작 스케줄 상태:</strong>
+                                            <span th:if="${scheduleInfo.dinnerStartSchedulerActive}" class="text-success">
+                                                <i class="fas fa-check-circle mr-1"></i>활성
+                                            </span>
+                                            <span th:unless="${scheduleInfo.dinnerStartSchedulerActive}" class="text-danger">
+                                                <i class="fas fa-times-circle mr-1"></i>비활성
+                                            </span>
+                                        </p>
+                                        <p><strong>저녁 종료 스케줄 상태:</strong>
+                                            <span th:if="${scheduleInfo.dinnerEndSchedulerActive}" class="text-success">
+                                                <i class="fas fa-check-circle mr-1"></i>활성
+                                            </span>
+                                            <span th:unless="${scheduleInfo.dinnerEndSchedulerActive}" class="text-danger">
+                                                <i class="fas fa-times-circle mr-1"></i>비활성
+                                            </span>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
             </div>
+            <!-- 페이지 콘텐츠 끝 -->
+
         </div>
+        <!-- 메인 콘텐츠 끝 -->
+
     </div>
+    <!-- 콘텐츠 래퍼 끝 -->
+
 </div>
+<!-- 페이지 래퍼 끝 -->
 
 <!-- 맨 위로 스크롤 버튼 -->
-<a class='scroll-to-top rounded' href='#page-top'>
-    <i class='fas fa-angle-up'></i>
+<a class="scroll-to-top rounded" href="#page-top">
+    <i class="fas fa-angle-up"></i>
 </a>
 
 <!-- 스크립트 포함 -->
 <th:block th:replace="~{fragments/scripts :: body}"></th:block>
+
+<script>
+    // 현재 시간을 기본값으로 설정하는 기능
+    function setCurrentTimeAsDefault() {
+        const lunchStartHourInput = document.getElementById('lunchStartHour');
+        const lunchStartMinuteInput = document.getElementById('lunchStartMinute');
+        const lunchEndHourInput = document.getElementById('lunchEndHour');
+        const lunchEndMinuteInput = document.getElementById('lunchEndMinute');
+        const dinnerStartHourInput = document.getElementById('dinnerStartHour');
+        const dinnerStartMinuteInput = document.getElementById('dinnerStartMinute');
+        const dinnerEndHourInput = document.getElementById('dinnerEndHour');
+        const dinnerEndMinuteInput = document.getElementById('dinnerEndMinute');
+
+        // 서버에서 제공된 값이 없으면 기본값 설정
+        if (!lunchStartHourInput.value) lunchStartHourInput.value = 12;
+        if (!lunchStartMinuteInput.value) lunchStartMinuteInput.value = 0;
+        if (!lunchEndHourInput.value) lunchEndHourInput.value = 14;
+        if (!lunchEndMinuteInput.value) lunchEndMinuteInput.value = 0;
+        if (!dinnerStartHourInput.value) dinnerStartHourInput.value = 18;
+        if (!dinnerStartMinuteInput.value) dinnerStartMinuteInput.value = 0;
+        if (!dinnerEndHourInput.value) dinnerEndHourInput.value = 20;
+        if (!dinnerEndMinuteInput.value) dinnerEndMinuteInput.value = 0;
+    }
+
+    // Cron 표현식 생성
+    function prepareCronExpressions(event, type) {
+        event.preventDefault();
+        const form = event.target;
+        const startHourInput = form.querySelector(`#${type}StartHour`);
+        const startMinuteInput = form.querySelector(`#${type}StartMinute`);
+        const endHourInput = form.querySelector(`#${type}EndHour`);
+        const endMinuteInput = form.querySelector(`#${type}EndMinute`);
+        const startCronInput = form.querySelector(`#${type}StartCron`);
+        const endCronInput = form.querySelector(`#${type}EndCron`);
+
+        const startHour = parseInt(startHourInput.value);
+        const startMinute = parseInt(startMinuteInput.value);
+        const endHour = parseInt(endHourInput.value);
+        const endMinute = parseInt(endMinuteInput.value);
+
+        // 유효성 검사
+        if (startHour < 0 || startHour > 23 || endHour < 0 || endHour > 23) {
+            alert('시간은 0~23 사이의 값을 입력해주세요.');
+            return;
+        }
+        if (startMinute < 0 || startMinute > 59 || endMinute < 0 || endMinute > 59) {
+            alert('분은 0~59 사이의 값을 입력해주세요.');
+            return;
+        }
+        if (startHour > endHour || (startHour === endHour && startMinute >= endMinute)) {
+            alert(`${type === 'lunch' ? '점심' : '저녁'} 시작 시간은 종료 시간보다 빠르거나 같을 수 없습니다.`);
+            return;
+        }
+
+        // Cron 표현식 생성 (예: "0 0 12 * * ?" for 12:00 daily)
+        startCronInput.value = `0 ${startMinute} ${startHour} * * ?`;
+        endCronInput.value = `0 ${endMinute} ${endHour} * * ?`;
+
+        // 폼 제출
+        form.submit();
+    }
+
+    // 페이지 로드 시 기본값 설정
+    document.addEventListener('DOMContentLoaded', setCurrentTimeAsDefault);
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#542 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 소상공인 물품 생성
- 소상공인 점심/저녁 상품 스케줄링
- 상품 판매 시간(점심상품 시작/종료 시간, 저녁상품 시작/종료 시간) 반환

### admin 페이지
  - 상품 타입 별 필터 적용
  - 상품 추가 페이지에 일반물품/소상공인 물품 등록 드롭다운 추가
  - 상품 판매 시간 UI 및 판매 시간 변경


## 🌄 이미지 첨부 **(Optional)**
<img src="https://github.com/user-attachments/assets/b7f1112e-82c7-4c1e-b59e-16f1341a131a" width="50%" height="50%"/>

## 🔧 앞으로의 과제 **(Optional)**

- 일괄 처리 에러
- LEVEL 기능 스케쥴러 수정
