### PR TITLE
548 refactor 배송 준비 중인 상품들을 배송 중으로 일괄 변경

### DIFF
--- a/src/main/java/com/codenear/butterfly/admin/order/dto/BulkCompleteDTO.java
+++ b/src/main/java/com/codenear/butterfly/admin/order/dto/BulkCompleteDTO.java
@@ -1,0 +1,9 @@
+package com.codenear.butterfly.admin.order.dto;
+
+import com.codenear.butterfly.payment.domain.dto.OrderStatus;
+
+import java.util.List;
+
+public record BulkCompleteDTO(List<Long> orderIds,
+                              OrderStatus status) {
+}

--- a/src/main/java/com/codenear/butterfly/admin/order/presentation/AdminOrderDetailsController.java
+++ b/src/main/java/com/codenear/butterfly/admin/order/presentation/AdminOrderDetailsController.java
@@ -1,6 +1,7 @@
 package com.codenear.butterfly.admin.order.presentation;
 
 import com.codenear.butterfly.admin.order.application.AdminOrderDetailsService;
+import com.codenear.butterfly.admin.order.dto.BulkCompleteDTO;
 import com.codenear.butterfly.global.dto.ResponseDTO;
 import com.codenear.butterfly.global.exception.ErrorCode;
 import com.codenear.butterfly.global.util.ResponseUtil;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
-import java.util.Map;
 
 @Controller
 @RequestMapping("/admin")
@@ -65,18 +66,17 @@ public class AdminOrderDetailsController {
         return "redirect:/admin/delivery-status";
     }
 
-    @PostMapping("/bulk-complete-orders")
+    @PatchMapping("/orders/status")
     @ResponseBody
-    public ResponseEntity<ResponseDTO> bulkCompleteOrders(@RequestBody Map<String, List<Long>> requestBody) {
-        List<Long> orderIds = requestBody.get("orderIds");
-
+    public ResponseEntity<ResponseDTO> bulkCompleteOrders(@RequestBody BulkCompleteDTO bulkCompleteDTO) {
+        List<Long> orderIds = bulkCompleteDTO.orderIds();
         if (orderIds == null || orderIds.isEmpty()) {
             return ResponseUtil.createErrorResponse(ErrorCode.PRODUCT_NOT_SELECTED, null);
         }
 
         try {
-            int processedCount = adminOrderDetailsService.bulkCompleteOrders(orderIds);
-            String message = "총 " + processedCount + "개의 주문이 배송 완료 처리되었습니다.";
+            int processedCount = adminOrderDetailsService.bulkChangeOrderStatus(orderIds, bulkCompleteDTO.status());
+            String message = String.format("총 %s개의 주문이 %s로 변경되었습니다.", processedCount, bulkCompleteDTO.status());
             return ResponseUtil.createSuccessResponse(message, null);
         } catch (Exception e) {
             return ResponseUtil.createErrorResponse(ErrorCode.SERVER_ERROR, null);

--- a/src/main/java/com/codenear/butterfly/payment/domain/repository/OrderDetailsRepository.java
+++ b/src/main/java/com/codenear/butterfly/payment/domain/repository/OrderDetailsRepository.java
@@ -19,8 +19,7 @@ public interface OrderDetailsRepository extends JpaRepository<OrderDetails, Long
     Page<OrderDetails> findByOrderStatus(OrderStatus status, Pageable pageable);
 
     @Modifying
-    @Query("UPDATE OrderDetails o SET o.orderStatus = :newStatus WHERE o.id IN :orderIds AND o.orderStatus = :currentStatus")
+    @Query("UPDATE OrderDetails o SET o.orderStatus = :newStatus WHERE o.id IN :orderIds")
     int updateOrderStatusInBulk(@Param("orderIds") List<Long> orderIds,
-                                @Param("currentStatus") OrderStatus currentStatus,
                                 @Param("newStatus") OrderStatus newStatus);
 }

--- a/src/main/resources/templates/admin/order/order-details.html
+++ b/src/main/resources/templates/admin/order/order-details.html
@@ -38,23 +38,26 @@
                 <div class="card shadow mb-4">
                     <div class="card-body">
                         <!--배송 중 일괄 배송 완료 -->
-                        <div class="mb-3" id="bulkActionContainer" th:if="${param.status != null && param.status[0] == 'DELIVERY'}">
-                            <div class="d-flex align-items-center">
+                        <div class="mb-3" id="bulkActionContainer">
+                            <div class="d-flex align-items-center" th:if="${param.status != null && (param.status[0] == 'DELIVERY' || param.status[0] == 'READY')}">
                                 <div class="custom-control custom-checkbox mr-2">
                                     <input type="checkbox" class="custom-control-input" id="selectAll">
                                     <label class="custom-control-label" for="selectAll">전체 선택</label>
                                 </div>
                                 <button id="bulkCompleteBtn" class="btn btn-success btn-sm ml-2" disabled>
-                                    <i class="fas fa-check"></i> 선택 항목 일괄 배송 완료
+                                    <i class="fas fa-check"></i>
+                                    <span th:if="${param.status[0] == 'DELIVERY'}">선택 항목 일괄 배송 완료</span>
+                                    <span th:if="${param.status[0] == 'READY'}">선택 항목 일괄 배송 중</span>
                                 </button>
                             </div>
                         </div>
+
 
                         <div class="table-responsive">
                             <table class="table table-bordered" id="orderTable">
                                 <thead>
                                 <tr>
-                                    <th th:if="${param.status != null && param.status[0] == 'DELIVERY'}" width="5%">
+                                    <th th:if="${param.status != null && (param.status[0] == 'DELIVERY' || param.status[0] == 'READY')}" width="5%">
                                         <span class="sr-only">선택</span>
                                     </th>
                                     <th>주문일</th>
@@ -68,7 +71,7 @@
                                 </thead>
                                 <tbody>
                                 <tr th:each="order : ${orders}">
-                                    <td th:if="${param.status != null && param.status[0] == 'DELIVERY'}">
+                                    <td th:if="${param.status != null && (param.status[0] == 'DELIVERY' || param.status[0] == 'READY')}">
                                         <div class="custom-control custom-checkbox">
                                             <input type="checkbox" class="custom-control-input order-checkbox"
                                                    th:id="'order-' + ${order.id}"
@@ -219,7 +222,7 @@
 
         const currentStatus = [[${param.status != null ? param.status[0] : null}]];
         console.log(currentStatus)
-        if (currentStatus === 'DELIVERY') {
+        if (currentStatus === 'DELIVERY' || currentStatus === 'READY') {
             const selectAllCheckbox = document.getElementById('selectAll');
             const orderCheckboxes = document.querySelectorAll('.order-checkbox');
             const bulkCompleteBtn = document.getElementById('bulkCompleteBtn');
@@ -266,15 +269,18 @@
             confirmBulkCompleteBtn.addEventListener('click', function() {
                 const selectedOrderIds = Array.from(document.querySelectorAll('.order-checkbox:checked'))
                     .map(checkbox => checkbox.getAttribute('data-order-id'));
-
+                const targetStatus = currentStatus === 'DELIVERY' ? 'COMPLETED' : 'DELIVERY';
                 // AJAX 요청으로 일괄 처리
-                fetch('/admin/bulk-complete-orders', {
-                    method: 'POST',
+                fetch('/admin/orders/status', {
+                    method: 'PATCH',
                     headers: {
                         'Content-Type': 'application/json',
                         'X-CSRF-TOKEN': document.querySelector('meta[name="_csrf"]')?.getAttribute('content')
                     },
-                    body: JSON.stringify({orderIds: selectedOrderIds})
+                    body: JSON.stringify({
+                        orderIds: selectedOrderIds,
+                        status: targetStatus
+                    })
                 })
                 .then(response => {
                     if (response.ok) {

--- a/src/test/java/com/codenear/butterfly/admin/order/application/AdminOrderDetailsServiceTest.java
+++ b/src/test/java/com/codenear/butterfly/admin/order/application/AdminOrderDetailsServiceTest.java
@@ -29,10 +29,10 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -86,14 +86,14 @@ class AdminOrderDetailsServiceTest {
         product1 = mock(ProductInventory.class);
         when(product1.getProductName()).thenReturn("상품A");
         when(product1.getOriginalPrice()).thenReturn(10000);
-        when(product1.getSaleRate()).thenReturn(BigDecimal.ZERO); // 기본 할인율 0%
-        when(product1.getCurrentDiscountRate()).thenReturn(BigDecimal.valueOf(20)); // 참여 할인율 20%
+        when(product1.getSaleRate()).thenReturn(BigDecimal.ZERO);
+        when(product1.getCurrentDiscountRate()).thenReturn(BigDecimal.valueOf(20));
 
         product2 = mock(ProductInventory.class);
         when(product2.getProductName()).thenReturn("상품B");
         when(product2.getOriginalPrice()).thenReturn(20000);
-        when(product2.getSaleRate()).thenReturn(BigDecimal.ZERO); // 기본 할인율 0%
-        when(product2.getCurrentDiscountRate()).thenReturn(BigDecimal.valueOf(10)); // 참여 할인율 10%
+        when(product2.getSaleRate()).thenReturn(BigDecimal.ZERO);
+        when(product2.getCurrentDiscountRate()).thenReturn(BigDecimal.valueOf(10));
 
         // OrderDetails 객체 생성
         order1 = createOrderDetails(101L, member1, "상품A", OrderStatus.DELIVERY, 1, 10000);
@@ -110,21 +110,18 @@ class AdminOrderDetailsServiceTest {
         when(order.getOrderStatus()).thenReturn(status);
         when(order.getQuantity()).thenReturn(quantity);
         when(order.getTotal()).thenReturn(total);
-
         return order;
     }
 
+    // DELIVERY → COMPLETED
     @Test
-    public void 일괄배송_성공() {
+    public void 일괄배송_성공_DELIVERY_to_COMPLETED() {
         // Given
         List<Long> orderIds = Arrays.asList(101L, 102L, 103L);
 
-        // 상태 업데이트 성공 (3건)
-        when(orderDetailsRepository.updateOrderStatusInBulk(
-                orderIds, OrderStatus.DELIVERY, OrderStatus.COMPLETED))
+        when(orderDetailsRepository.updateOrderStatusInBulk(orderIds, OrderStatus.COMPLETED))
                 .thenReturn(3);
 
-        // 업데이트된 주문들의 상태가 COMPLETED로 변경됨
         OrderDetails completedOrder1 = createOrderDetails(101L, member1, "상품A", OrderStatus.COMPLETED, 1, 10000);
         OrderDetails completedOrder2 = createOrderDetails(102L, member1, "상품B", OrderStatus.COMPLETED, 1, 20000);
         OrderDetails completedOrder3 = createOrderDetails(103L, member2, "상품A", OrderStatus.COMPLETED, 1, 10000);
@@ -132,24 +129,17 @@ class AdminOrderDetailsServiceTest {
         when(orderDetailsRepository.findAllById(orderIds))
                 .thenReturn(Arrays.asList(completedOrder1, completedOrder2, completedOrder3));
 
-        // 상품 정보 조회
         Set<String> productNames = new HashSet<>(Arrays.asList("상품A", "상품B"));
         when(productInventoryRepository.findAllByProductNameIn(productNames))
                 .thenReturn(Arrays.asList(product1, product2));
 
         // When
-        int result = orderService.bulkCompleteOrders(orderIds);
+        int result = orderService.bulkChangeOrderStatus(orderIds, OrderStatus.COMPLETED);
 
         // Then
         assertThat(result).isEqualTo(3);
-
-        // 포인트 업데이트 검증 - 실제 계산 결과 반영
-        // 상품A: 10000 - 8000 = 2000 (20% 할인)
-        // 상품B: 20000 - 18000 = 2000 (10% 할인)
         verify(pointRepository).increasePointByMemberId(eq(1L), eq(4000)); // member1: 2000 (상품A) + 2000 (상품B)
         verify(pointRepository).increasePointByMemberId(eq(2L), eq(2000)); // member2: 2000 (상품A)
-
-        // 알림 발송 검증
         verify(fcmFacade, times(2)).sendMessage(eq(NotifyMessage.PRODUCT_ARRIVAL), memberIdCaptor.capture());
         verify(fcmFacade, times(2)).sendMessage(eq(NotifyMessage.REWARD_POINT), memberIdCaptor.capture());
 
@@ -157,66 +147,114 @@ class AdminOrderDetailsServiceTest {
         assertThat(capturedMemberIds).contains(1L, 2L);
     }
 
+    // READY → DELIVERY
+    @Test
+    public void 일괄배송_성공_READY_to_DELIVERY() {
+        // Given
+        List<Long> orderIds = Arrays.asList(101L, 102L, 103L);
+
+        // READY 상태로 주문 설정
+        order1 = createOrderDetails(101L, member1, "상품A", OrderStatus.READY, 1, 10000);
+        order2 = createOrderDetails(102L, member1, "상품B", OrderStatus.READY, 1, 20000);
+        order3 = createOrderDetails(103L, member2, "상품A", OrderStatus.READY, 1, 10000);
+
+        when(orderDetailsRepository.updateOrderStatusInBulk(orderIds, OrderStatus.DELIVERY))
+                .thenReturn(3);
+
+        OrderDetails deliveryOrder1 = createOrderDetails(101L, member1, "상품A", OrderStatus.DELIVERY, 1, 10000);
+        OrderDetails deliveryOrder2 = createOrderDetails(102L, member1, "상품B", OrderStatus.DELIVERY, 1, 20000);
+        OrderDetails deliveryOrder3 = createOrderDetails(103L, member2, "상품A", OrderStatus.DELIVERY, 1, 10000);
+
+        when(orderDetailsRepository.findAllById(orderIds))
+                .thenReturn(Arrays.asList(deliveryOrder1, deliveryOrder2, deliveryOrder3));
+
+        // When
+        int result = orderService.bulkChangeOrderStatus(orderIds, OrderStatus.DELIVERY);
+
+        // Then
+        assertThat(result).isEqualTo(3);
+        verify(pointRepository, never()).increasePointByMemberId(anyLong(), anyInt());
+        verify(fcmFacade, never()).sendMessage(any(NotifyMessage.class), anyLong());
+    }
+
+    // 상태 변경 실패
     @Test
     public void 일괄배송_상태변경_실패() {
         // Given
         List<Long> orderIds = Arrays.asList(101L, 102L, 103L);
 
-        // 상태 업데이트 실패 (0건)
-        when(orderDetailsRepository.updateOrderStatusInBulk(
-                orderIds, OrderStatus.DELIVERY, OrderStatus.COMPLETED))
+        when(orderDetailsRepository.updateOrderStatusInBulk(orderIds, OrderStatus.COMPLETED))
                 .thenReturn(0);
 
         // When
-        int result = orderService.bulkCompleteOrders(orderIds);
+        int result = orderService.bulkChangeOrderStatus(orderIds, OrderStatus.COMPLETED);
 
         // Then
         assertThat(result).isEqualTo(0);
-
-        // processPointsAndNotificationsBatch 메서드가 호출되지 않았는지 검증
         verify(productInventoryRepository, never()).findAllByProductNameIn(any());
         verify(pointRepository, never()).increasePointByMemberId(anyLong(), anyInt());
         verify(fcmFacade, never()).sendMessage(any(NotifyMessage.class), anyLong());
     }
 
+    // 일부 성공 (DELIVERY → COMPLETED)
     @Test
-    public void 일괄배송_일부_성공() {
+    public void 일괄배송_일부_성공_DELIVERY_to_COMPLETED() {
         // Given
         List<Long> orderIds = Arrays.asList(101L, 102L, 103L);
 
-        // 상태 업데이트 부분 성공 (2건)
-        when(orderDetailsRepository.updateOrderStatusInBulk(
-                orderIds, OrderStatus.DELIVERY, OrderStatus.COMPLETED))
+        when(orderDetailsRepository.updateOrderStatusInBulk(orderIds, OrderStatus.COMPLETED))
                 .thenReturn(2);
 
-        // 첫 번째와 세 번째 주문만 COMPLETED로 변경됨
         OrderDetails completedOrder1 = createOrderDetails(101L, member1, "상품A", OrderStatus.COMPLETED, 1, 10000);
-        OrderDetails nonCompletedOrder2 = createOrderDetails(102L, member1, "상품B", OrderStatus.DELIVERY, 1, 20000); // 이 주문은 업데이트 안됨
+        OrderDetails nonCompletedOrder2 = createOrderDetails(102L, member1, "상품B", OrderStatus.DELIVERY, 1, 20000);
         OrderDetails completedOrder3 = createOrderDetails(103L, member2, "상품A", OrderStatus.COMPLETED, 1, 10000);
 
         when(orderDetailsRepository.findAllById(orderIds))
                 .thenReturn(Arrays.asList(completedOrder1, nonCompletedOrder2, completedOrder3));
 
-        // 상품 정보 조회 - 상품A만 필요
-        Set<String> productNames = new HashSet<>(Arrays.asList("상품A"));
+        Set<String> productNames = new HashSet<>(Arrays.asList("상품A", "상품B"));
         when(productInventoryRepository.findAllByProductNameIn(productNames))
                 .thenReturn(Arrays.asList(product1));
 
         // When
-        int result = orderService.bulkCompleteOrders(orderIds);
+        int result = orderService.bulkChangeOrderStatus(orderIds, OrderStatus.COMPLETED);
 
         // Then
         assertThat(result).isEqualTo(2);
-
-        // filter 메서드에 의해 COMPLETED 상태인 주문들만 처리되는지 검증
-        verify(pointRepository).increasePointByMemberId(eq(1L), eq(2000)); // member1: 2000 (상품A)
-        verify(pointRepository).increasePointByMemberId(eq(2L), eq(2000)); // member2: 2000 (상품A)
-
-        // 알림 발송 검증
+        verify(pointRepository).increasePointByMemberId(eq(1L), eq(2000));
+        verify(pointRepository).increasePointByMemberId(eq(2L), eq(2000));
         verify(fcmFacade, times(2)).sendMessage(eq(NotifyMessage.PRODUCT_ARRIVAL), anyLong());
         verify(fcmFacade, times(2)).sendMessage(eq(NotifyMessage.REWARD_POINT), anyLong());
     }
 
+    // 일부 성공 (READY → DELIVERY)
+    @Test
+    public void 일괄배송_일부_성공_READY_to_DELIVERY() {
+        // Given
+        List<Long> orderIds = Arrays.asList(101L, 102L, 103L);
+
+        order1 = createOrderDetails(101L, member1, "상품A", OrderStatus.READY, 1, 10000);
+        order2 = createOrderDetails(102L, member1, "상품B", OrderStatus.READY, 1, 20000);
+        order3 = createOrderDetails(103L, member2, "상품A", OrderStatus.READY, 1, 10000);
+
+        when(orderDetailsRepository.updateOrderStatusInBulk(orderIds, OrderStatus.DELIVERY))
+                .thenReturn(2);
+
+        OrderDetails deliveryOrder1 = createOrderDetails(101L, member1, "상품A", OrderStatus.DELIVERY, 1, 10000);
+        OrderDetails nonDeliveryOrder2 = createOrderDetails(102L, member1, "상품B", OrderStatus.READY, 1, 20000);
+        OrderDetails deliveryOrder3 = createOrderDetails(103L, member2, "상품A", OrderStatus.DELIVERY, 1, 10000);
+
+        when(orderDetailsRepository.findAllById(orderIds))
+                .thenReturn(Arrays.asList(deliveryOrder1, nonDeliveryOrder2, deliveryOrder3));
+
+        // When
+        int result = orderService.bulkChangeOrderStatus(orderIds, OrderStatus.DELIVERY);
+
+        // Then
+        assertThat(result).isEqualTo(2);
+    }
+
+    // DELIVERY → COMPLETED 포인트백 O
     @Test
     public void 배송완료_포인트지급_및_알림발송() {
         // Given
@@ -224,10 +262,8 @@ class AdminOrderDetailsServiceTest {
         OrderDetails order = createOrderDetails(orderId, member1, "상품A", OrderStatus.DELIVERY, 1, 10000);
         when(orderDetailsRepository.findById(orderId)).thenReturn(Optional.of(order));
 
-        // 상품 정보 조회
         when(productInventoryRepository.findProductByProductName("상품A")).thenReturn(product1);
 
-        // 회원 포인트
         Point memberPoint = mock(Point.class);
         when(pointRepository.findByMember(member1)).thenReturn(Optional.of(memberPoint));
 
@@ -237,32 +273,27 @@ class AdminOrderDetailsServiceTest {
         // Then
         verify(order).updateOrderStatus(OrderStatus.COMPLETED);
         verify(orderDetailsRepository).save(order);
-
-        // 포인트 증가 검증 - 실제 Price 계산 결과 (10000 - 8000 = 2000)
         verify(memberPoint).increasePoint(2000);
-
-        // 알림 발송 검증
         verify(fcmFacade).sendMessage(NotifyMessage.PRODUCT_ARRIVAL, member1.getId());
         verify(fcmFacade).sendMessage(NotifyMessage.REWARD_POINT, member1.getId());
     }
 
+    // DELIVERY → COMPLETED 포인트백 X
     @Test
-    public void 배송완료_포인트없는경우_알림만발송() {
+    public void 배송완료_포인트백없는경우_알림만발송() {
         // Given
         Long orderId = 101L;
         OrderDetails order = createOrderDetails(orderId, member1, "상품A", OrderStatus.DELIVERY, 1, 10000);
         when(orderDetailsRepository.findById(orderId)).thenReturn(Optional.of(order));
 
-        // 상품 정보 조회 - 현재가가 구매가와 동일하도록 설정
         ProductInventory samePrice = mock(ProductInventory.class);
         when(samePrice.getProductName()).thenReturn("상품A");
         when(samePrice.getOriginalPrice()).thenReturn(10000);
         when(samePrice.getSaleRate()).thenReturn(BigDecimal.ZERO);
-        when(samePrice.getCurrentDiscountRate()).thenReturn(BigDecimal.ZERO); // 할인 없음
+        when(samePrice.getCurrentDiscountRate()).thenReturn(BigDecimal.ZERO);
 
         when(productInventoryRepository.findProductByProductName("상품A")).thenReturn(samePrice);
 
-        // 회원 포인트
         Point memberPoint = mock(Point.class);
         when(pointRepository.findByMember(member1)).thenReturn(Optional.of(memberPoint));
 
@@ -272,11 +303,26 @@ class AdminOrderDetailsServiceTest {
         // Then
         verify(order).updateOrderStatus(OrderStatus.COMPLETED);
         verify(orderDetailsRepository).save(order);
-
         verify(memberPoint, never()).increasePoint(anyInt());
-
-        // 상품 도착 알림만 발송됨
         verify(fcmFacade).sendMessage(NotifyMessage.PRODUCT_ARRIVAL, member1.getId());
         verify(fcmFacade, never()).sendMessage(eq(NotifyMessage.REWARD_POINT), anyLong());
+    }
+
+    // READY → DELIVERY
+    @Test
+    public void 배송중_상태변경_포인트와_알림_없음() {
+        // Given
+        Long orderId = 101L;
+        OrderDetails order = createOrderDetails(orderId, member1, "상품A", OrderStatus.READY, 1, 10000);
+        when(orderDetailsRepository.findById(orderId)).thenReturn(Optional.of(order));
+
+        // When
+        orderService.updateOrderStatus(orderId, OrderStatus.DELIVERY);
+
+        // Then
+        verify(order).updateOrderStatus(OrderStatus.DELIVERY);
+        verify(orderDetailsRepository).save(order);
+        verify(pointRepository, never()).increasePointByMemberId(anyLong(), anyInt());
+        verify(fcmFacade, never()).sendMessage(any(NotifyMessage.class), anyLong());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#548 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 일괄 주문 상태 변경 처리 확장
- 기존 POST로 받던 요청을 PATCH로 변경
  - 상태 추가가 아닌 변경이기 떄문에 Restful하게 수정
- 어드민 페이지 배송 준비 중 필터에서 일괄 선택 변경 추가
- READY -> DELIVERY 상태변경 테스트코드 추가

## 🔧 앞으로의 과제 **(Optional)**

- 어드민 페이지 이동 시 필터 초기화 오류 수정
